### PR TITLE
[test] 멤버 수정 기능 테스트 코드 추가

### DIFF
--- a/order/src/main/java/com/ipia/order/member/service/MemberService.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberService.java
@@ -33,4 +33,14 @@ public interface MemberService {
      * 이름으로 멤버 조회
      */
     List<Member> findByName(String name);
+
+    /**
+     * 닉네임(이름) 변경
+     */
+    Member updateNickname(Long id, String newNickname);
+
+    /**
+     * 비밀번호 변경
+     */
+    void updatePassword(Long id, String currentPassword, String newPassword);
 }

--- a/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
@@ -65,4 +65,14 @@ public class MemberServiceImpl implements MemberService {
         }
         return memberRepository.findByName(name);
     }
+
+    @Override
+    public Member updateNickname(Long id, String newNickname) {
+        throw new UnsupportedOperationException("updateNickname is not implemented yet");
+    }
+
+    @Override
+    public void updatePassword(Long id, String currentPassword, String newPassword) {
+        throw new UnsupportedOperationException("updatePassword is not implemented yet");
+    }
 }


### PR DESCRIPTION


## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

- 회원 닉네임/비밀번호 수정 기능에 대한 단위 테스트를 TDD Red 단계로 추가하고, 서비스에 미구현 명시를 반영했습니다.
### 관련 이슈
- Close: #21 

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- Member 서비스 단위 테스트에 수정 관련 Red 케이스 추가
- MemberServiceImplTest.MemberUpdateTest
- 닉네임 변경: 성공/존재하지 않는 ID/NULL ID/공백 닉네임
- 비밀번호 변경: 성공/존재하지 않는 ID/현재 비밀번호 불일치/새 비밀번호 정책 위반
- Repository 단위 테스트에 수정 관련 케이스 추가
- MemberService에 updateNickname, updatePassword API 추가 (현재 구현 미제공)

### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원 프로필 관리 기능 추가: 닉네임 변경 및 비밀번호 변경을 지원합니다.
  - 오류 처리 강화: 잘못된 ID, 빈 닉네임, 현재 비밀번호 불일치, 비밀번호 정책 위반 등 상황에 대한 예외 처리를 포함합니다.
- 테스트
  - 닉네임/비밀번호 변경의 성공·실패 시나리오에 대한 단위 테스트 추가.
  - 이름 변경 성공, 이메일 중복 업데이트 실패(무결성 위반) 검증 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->