### PR TITLE
[test] 회원 탈퇴 기능 테스트 코드 추가 (#25)

### DIFF
--- a/order/src/main/java/com/ipia/order/member/domain/Member.java
+++ b/order/src/main/java/com/ipia/order/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.ipia.order.member.domain;
 
+import java.time.LocalDateTime;
+
 import org.springframework.util.StringUtils;
 
 import com.ipia.order.common.entity.BaseEntity;
@@ -33,6 +35,12 @@ public class Member extends BaseEntity {
 
     @Column(name = "email", nullable = false, length = 200)
     private String email;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @Builder
     private Member(String name, String email) {
@@ -70,6 +78,29 @@ public class Member extends BaseEntity {
     public void changeName(String newName) {
         validateName(newName);
         this.name = newName;
+    }
+
+    /**
+     * 회원 활성 상태 확인
+     */
+    public boolean isActive() {
+        // TODO: 구현 예정
+        throw new UnsupportedOperationException("구현 예정");
+    }
+
+    /**
+     * 회원 상태를 비활성으로 변경
+     */
+    public void deactivate() {
+        // TODO: 구현 예정
+        throw new UnsupportedOperationException("구현 예정");
+    }
+
+    /**
+     * 탈퇴 시간 조회
+     */
+    public LocalDateTime getDeletedAt() {
+        return this.deletedAt;
     }
 
 }

--- a/order/src/main/java/com/ipia/order/member/service/MemberService.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberService.java
@@ -43,4 +43,9 @@ public interface MemberService {
      * 비밀번호 변경
      */
     void updatePassword(Long id, String currentPassword, String newPassword);
+
+    /**
+     * 회원 탈퇴
+     */
+    void withdraw(Long id);
 }

--- a/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
@@ -103,4 +103,9 @@ public class MemberServiceImpl implements MemberService {
         // 실제 암호 저장 로직이 없으므로 저장만 수행하여 테스트의 저장 호출을 만족
         memberRepository.save(member);
     }
+
+    @Override
+    public void withdraw(Long id) {
+
+    }
 }

--- a/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
@@ -538,4 +538,223 @@ class MemberServiceImplTest {
             verify(memberRepository, never()).save(any(Member.class));
         }
     }
+
+    @Nested
+    @DisplayName("멤버 탈퇴 테스트")
+    class MemberWithdrawTest {
+
+        @Test
+        @DisplayName("정상적인 멤버 탈퇴 성공")
+        void withdraw_Success() {
+            // given
+            Long memberId = 1L;
+            Member activeMember = Member.builder()
+                    .name("홍길동")
+                    .email("hong@example.com")
+                    .build();
+            
+            given(memberRepository.findById(memberId))
+                    .willReturn(java.util.Optional.of(activeMember));
+            given(memberRepository.save(any(Member.class)))
+                    .willReturn(activeMember);
+
+            // when
+            memberService.withdraw(memberId);
+
+            // then
+            verify(memberRepository).findById(memberId);
+            verify(memberRepository).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 탈퇴 시도 시 MemberHandler 발생")
+        void withdraw_Fail_NotFound() {
+            // given
+            Long nonExistentId = 999L;
+            given(memberRepository.findById(nonExistentId))
+                    .willReturn(java.util.Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.withdraw(nonExistentId))
+                    .isInstanceOf(MemberHandler.class);
+            
+            verify(memberRepository).findById(nonExistentId);
+            verify(memberRepository, never()).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("null ID로 탈퇴 시도 시 MemberHandler 발생")
+        void withdraw_Fail_NullId() {
+            // when & then
+            assertThatThrownBy(() -> memberService.withdraw(null))
+                    .isInstanceOf(MemberHandler.class);
+            
+            verify(memberRepository, never()).findById(any());
+            verify(memberRepository, never()).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("이미 탈퇴한 회원 탈퇴 시도 시 MemberHandler 발생")
+        void withdraw_Fail_AlreadyInactive() {
+            // given
+            Long memberId = 1L;
+            Member inactiveMember = Member.builder()
+                    .name("홍길동")
+                    .email("hong@example.com")
+                    .build();
+            // 이미 탈퇴한 상태로 설정 (실제 구현에서는 isActive() 메서드로 확인)
+            // inactiveMember.deactivate(); // 구현 후 활성화
+            
+            given(memberRepository.findById(memberId))
+                    .willReturn(java.util.Optional.of(inactiveMember));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.withdraw(memberId))
+                    .isInstanceOf(MemberHandler.class);
+            
+            verify(memberRepository).findById(memberId);
+            verify(memberRepository, never()).save(any(Member.class));
+        }
+
+        @Test
+        @DisplayName("Repository 저장 실패 시 예외 전파")
+        void withdraw_Fail_RepositorySaveFailure() {
+            // given
+            Long memberId = 1L;
+            Member activeMember = Member.builder()
+                    .name("홍길동")
+                    .email("hong@example.com")
+                    .build();
+            
+            given(memberRepository.findById(memberId))
+                    .willReturn(java.util.Optional.of(activeMember));
+            given(memberRepository.save(any(Member.class)))
+                    .willThrow(new RuntimeException("데이터베이스 저장 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.withdraw(memberId))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("데이터베이스 저장 실패");
+            
+            verify(memberRepository).findById(memberId);
+            verify(memberRepository).save(any(Member.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("탈퇴 회원 제외 조회 테스트")
+    class ExcludeInactiveMembersTest {
+
+        @Test
+        @DisplayName("ID로 조회 시 탈퇴한 회원은 조회되지 않음")
+        void findById_ExcludesInactiveMembers() {
+            // given
+            Long memberId = 1L;
+            Member inactiveMember = Member.builder()
+                    .name("홍길동")
+                    .email("hong@example.com")
+                    .build();
+            // 탈퇴한 상태로 설정 (실제 구현에서는 isActive() 메서드로 확인)
+            // inactiveMember.withdraw();
+            
+            given(memberRepository.findById(memberId))
+                    .willReturn(java.util.Optional.of(inactiveMember));
+
+            // when & then
+            // 실제 구현에서는 탈퇴한 회원에 대해 MEMBER_NOT_FOUND 예외 발생
+            // assertThatThrownBy(() -> memberService.findById(memberId))
+            //         .isInstanceOf(MemberHandler.class);
+            
+            // 현재는 구현되지 않았으므로 주석 처리
+            // 구현 후에는 탈퇴한 회원이 조회되지 않는 것을 검증
+        }
+
+        @Test
+        @DisplayName("이메일로 조회 시 탈퇴한 회원은 조회되지 않음")
+        void findByEmail_ExcludesInactiveMembers() {
+            // given
+            String email = "hong@example.com";
+            Member inactiveMember = Member.builder()
+                    .name("홍길동")
+                    .email(email)
+                    .build();
+            // 탈퇴한 상태로 설정
+            // inactiveMember.deactivate();
+            
+            given(memberRepository.findByEmail(email))
+                    .willReturn(java.util.Optional.of(inactiveMember));
+
+            // when & then
+            // 실제 구현에서는 탈퇴한 회원에 대해 MEMBER_NOT_FOUND 예외 발생
+            // assertThatThrownBy(() -> memberService.findByEmail(email))
+            //         .isInstanceOf(MemberHandler.class);
+            
+            // 현재는 구현되지 않았으므로 주석 처리
+        }
+
+        @Test
+        @DisplayName("이름으로 조회 시 탈퇴한 회원은 제외됨")
+        void findByName_ExcludesInactiveMembers() {
+            // given
+            String name = "홍길동";
+            Member activeMember = Member.builder()
+                    .name(name)
+                    .email("active@example.com")
+                    .build();
+            Member inactiveMember = Member.builder()
+                    .name(name)
+                    .email("inactive@example.com")
+                    .build();
+            // 탈퇴한 상태로 설정
+            // inactiveMember.deactivate();
+            
+            java.util.List<Member> members = java.util.List.of(activeMember);
+            given(memberRepository.findByName(name))
+                    .willReturn(members);
+
+            // when
+            var result = memberService.findByName(name);
+
+            // then
+            // 실제 구현에서는 활성 회원만 조회되어야 함
+            assertThat(result).hasSize(1);
+            assertThat(result).extracting(Member::getEmail).containsOnly("active@example.com");
+            
+            // 현재는 구현되지 않았으므로 주석 처리된 부분이 실제 동작해야 함
+        }
+
+        @Test
+        @DisplayName("전체 조회 시 탈퇴한 회원은 제외됨")
+        void findAll_ExcludesInactiveMembers() {
+            // given
+            Member activeMember1 = Member.builder()
+                    .name("홍길동")
+                    .email("hong1@example.com")
+                    .build();
+            Member activeMember2 = Member.builder()
+                    .name("김철수")
+                    .email("kim@example.com")
+                    .build();
+            Member inactiveMember = Member.builder()
+                    .name("이영희")
+                    .email("lee@example.com")
+                    .build();
+            // 탈퇴한 상태로 설정
+            // inactiveMember.deactivate();
+            
+            java.util.List<Member> activeMembers = java.util.List.of(activeMember1, activeMember2);
+            given(memberRepository.findAll())
+                    .willReturn(activeMembers);
+
+            // when
+            var result = memberService.findAll();
+
+            // then
+            // 실제 구현에서는 활성 회원만 조회되어야 함
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(Member::getEmail).containsExactlyInAnyOrder("hong1@example.com", "kim@example.com");
+            
+            // 현재는 구현되지 않았으므로 주석 처리된 부분이 실제 동작해야 함
+        }
+    }
 }


### PR DESCRIPTION


## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

### 관련 이슈
- Close: #25 

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- Member 클래스에 isActive 및 deletedAt 필드 추가
- MemberService 인터페이스에 withdraw 메서드 추가
- MemberServiceImpl 클래스에 withdraw 메서드 기본 구현 추가
- 멤버 탈퇴 관련 테스트 케이스 추가 및 기존 테스트 업데이트

### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원 탈퇴(비활성화) 기능 추가: 계정 비활성화 및 삭제 시각 기록 지원
  - 신규 회원 기본 상태를 활성으로 설정
  - 비활성 회원은 조회/검색/목록 결과에서 제외되도록 동작 반영 예정
- 테스트
  - 회원 탈퇴 성공/실패 시나리오 및 예외 경로에 대한 테스트 추가
  - 비활성 회원 제외 동작 검증 테스트 추가(일부 보완 예정)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->