### PR TITLE
[feat] 회원 탈퇴 기능 구현 및 테스트 통과 (#26)

### DIFF
--- a/order/src/main/java/com/ipia/order/member/domain/Member.java
+++ b/order/src/main/java/com/ipia/order/member/domain/Member.java
@@ -84,16 +84,18 @@ public class Member extends BaseEntity {
      * 회원 활성 상태 확인
      */
     public boolean isActive() {
-        // TODO: 구현 예정
-        throw new UnsupportedOperationException("구현 예정");
+        return this.isActive;
     }
 
     /**
      * 회원 상태를 비활성으로 변경
      */
     public void deactivate() {
-        // TODO: 구현 예정
-        throw new UnsupportedOperationException("구현 예정");
+        if (!this.isActive) {
+            throw new IllegalStateException("이미 탈퇴한 회원입니다");
+        }
+        this.isActive = false;
+        this.deletedAt = LocalDateTime.now();
     }
 
     /**

--- a/order/src/main/java/com/ipia/order/member/repository/MemberRepository.java
+++ b/order/src/main/java/com/ipia/order/member/repository/MemberRepository.java
@@ -1,10 +1,12 @@
 package com.ipia.order.member.repository;
 
-import com.ipia.order.member.domain.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ipia.order.member.domain.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -13,4 +15,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     List<Member> findByName(String name);
+    
+    // 활성 회원만 조회하는 메서드들
+    List<Member> findAllByIsActiveTrue();
+    
+    Optional<Member> findByIdAndIsActiveTrue(Long id);
+    
+    Optional<Member> findByEmailAndIsActiveTrue(String email);
+    
+    List<Member> findByNameAndIsActiveTrue(String name);
 }

--- a/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
@@ -1,12 +1,14 @@
 package com.ipia.order.member.service;
 
-import com.ipia.order.member.domain.Member;
-import com.ipia.order.member.repository.MemberRepository;
-import com.ipia.order.common.exception.member.MemberHandler;
-import com.ipia.order.common.exception.member.status.MemberErrorStatus;
-import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.ipia.order.common.exception.member.MemberHandler;
+import com.ipia.order.common.exception.member.status.MemberErrorStatus;
+import com.ipia.order.member.domain.Member;
+import com.ipia.order.member.repository.MemberRepository;
 
 @Service
 public class MemberServiceImpl implements MemberService {
@@ -40,6 +42,12 @@ public class MemberServiceImpl implements MemberService {
         }
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        
+        // 탈퇴한 회원은 조회하지 않음
+        if (!member.isActive()) {
+            throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
+        }
+        
         return Optional.of(member);
     }
 
@@ -50,6 +58,12 @@ public class MemberServiceImpl implements MemberService {
         }
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+        
+        // 탈퇴한 회원은 조회하지 않음
+        if (!member.isActive()) {
+            throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
+        }
+        
         return Optional.of(member);
     }
 
@@ -106,6 +120,20 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void withdraw(Long id) {
+        if (id == null) {
+            throw new MemberHandler(MemberErrorStatus.INVALID_INPUT);
+        }
 
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이미 탈퇴한 회원인지 확인
+        if (!member.isActive()) {
+            throw new MemberHandler(MemberErrorStatus.ALREADY_INACTIVE);
+        }
+
+        // 회원 탈퇴 처리
+        member.deactivate();
+        memberRepository.save(member);
     }
 }

--- a/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/member/service/MemberServiceImpl.java
@@ -40,14 +40,8 @@ public class MemberServiceImpl implements MemberService {
         if (id == null) {
             throw new MemberHandler(MemberErrorStatus.INVALID_INPUT);
         }
-        Member member = memberRepository.findById(id)
+        Member member = memberRepository.findByIdAndIsActiveTrue(id)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
-        
-        // 탈퇴한 회원은 조회하지 않음
-        if (!member.isActive()) {
-            throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
-        }
-        
         return Optional.of(member);
     }
 
@@ -56,20 +50,14 @@ public class MemberServiceImpl implements MemberService {
         if (email == null || email.isBlank()) {
             throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
         }
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndIsActiveTrue(email)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
-        
-        // 탈퇴한 회원은 조회하지 않음
-        if (!member.isActive()) {
-            throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
-        }
-        
         return Optional.of(member);
     }
 
     @Override
     public List<Member> findAll() {
-        return memberRepository.findAll();
+        return memberRepository.findAllByIsActiveTrue();
     }
 
     @Override
@@ -77,7 +65,7 @@ public class MemberServiceImpl implements MemberService {
         if (name == null || name.isBlank()) {
             throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
         }
-        return memberRepository.findByName(name);
+        return memberRepository.findByNameAndIsActiveTrue(name);
     }
 
     @Override
@@ -105,6 +93,11 @@ public class MemberServiceImpl implements MemberService {
 
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND));
+
+        // 탈퇴한 회원은 비밀번호 변경 불가
+        if (!member.isActive()) {
+            throw new MemberHandler(MemberErrorStatus.MEMBER_NOT_FOUND);
+        }
 
         // 현재 비밀번호 검증/저장은 아직 도메인에 없으므로 최소 구현: 정책 위반/불일치 시 예외
         if (!currentPassword.equals("currentPass123!")) {

--- a/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
+++ b/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
@@ -600,24 +600,22 @@ class MemberRepositoryTest {
         @DisplayName("탈퇴한 회원은 전체 조회에서 제외됨")
         void findAll_ExcludesInactiveMembers() {
             // given
-            // Member activeMember1 = memberRepository.save(validMember);
-            // Member activeMember2 = memberRepository.save(Member.builder()
-            //         .name("김철수")
-            //         .email("kim@example.com")
-            //         .build());
-            // entityManager.flush();
+            Member activeMember1 = memberRepository.save(validMember);
+            Member activeMember2 = memberRepository.save(Member.builder()
+                    .name("김철수")
+                    .email("kim@example.com")
+                    .build());
+            entityManager.flush();
 
-            // // when: 한 명 탈퇴 처리
-            //  activeMember1.deactivate();
-            //  memberRepository.save(activeMember1);
-            //  entityManager.flush();
+            // when: 한 명 탈퇴 처리
+            activeMember1.deactivate();
+            memberRepository.save(activeMember1);
+            entityManager.flush();
 
-            // // then: 활성 회원만 조회되어야 함
-            //  var allMembers = memberRepository.findAll();
-            //  assertThat(allMembers).hasSize(1);
-            //  assertThat(allMembers).extracting(Member::getName).containsOnly("김철수");
-            
-            // // 현재는 구현되지 않았으므로 주석 처리
+            // then: 활성 회원만 조회되어야 함
+            var allActiveMembers = memberRepository.findAllByIsActiveTrue();
+            assertThat(allActiveMembers).hasSize(1);
+            assertThat(allActiveMembers).extracting(Member::getName).containsOnly("김철수");
         }
     }
 

--- a/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
+++ b/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
@@ -600,24 +600,24 @@ class MemberRepositoryTest {
         @DisplayName("탈퇴한 회원은 전체 조회에서 제외됨")
         void findAll_ExcludesInactiveMembers() {
             // given
-            Member activeMember1 = memberRepository.save(validMember);
-            Member activeMember2 = memberRepository.save(Member.builder()
-                    .name("김철수")
-                    .email("kim@example.com")
-                    .build());
-            entityManager.flush();
+            // Member activeMember1 = memberRepository.save(validMember);
+            // Member activeMember2 = memberRepository.save(Member.builder()
+            //         .name("김철수")
+            //         .email("kim@example.com")
+            //         .build());
+            // entityManager.flush();
 
-            // when: 한 명 탈퇴 처리
-             activeMember1.deactivate();
-             memberRepository.save(activeMember1);
-             entityManager.flush();
+            // // when: 한 명 탈퇴 처리
+            //  activeMember1.deactivate();
+            //  memberRepository.save(activeMember1);
+            //  entityManager.flush();
 
-            // then: 활성 회원만 조회되어야 함
-             var allMembers = memberRepository.findAll();
-             assertThat(allMembers).hasSize(1);
-             assertThat(allMembers).extracting(Member::getName).containsOnly("김철수");
+            // // then: 활성 회원만 조회되어야 함
+            //  var allMembers = memberRepository.findAll();
+            //  assertThat(allMembers).hasSize(1);
+            //  assertThat(allMembers).extracting(Member::getName).containsOnly("김철수");
             
-            // 현재는 구현되지 않았으므로 주석 처리
+            // // 현재는 구현되지 않았으므로 주석 처리
         }
     }
 

--- a/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
+++ b/order/src/test/java/com/ipia/order/member/repository/MemberRepositoryTest.java
@@ -608,14 +608,14 @@ class MemberRepositoryTest {
             entityManager.flush();
 
             // when: 한 명 탈퇴 처리
-            // activeMember1.deactivate();
-            // memberRepository.save(activeMember1);
-            // entityManager.flush();
+             activeMember1.deactivate();
+             memberRepository.save(activeMember1);
+             entityManager.flush();
 
             // then: 활성 회원만 조회되어야 함
-            // var allMembers = memberRepository.findAll();
-            // assertThat(allMembers).hasSize(1);
-            // assertThat(allMembers).extracting(Member::getName).containsOnly("김철수");
+             var allMembers = memberRepository.findAll();
+             assertThat(allMembers).hasSize(1);
+             assertThat(allMembers).extracting(Member::getName).containsOnly("김철수");
             
             // 현재는 구현되지 않았으므로 주석 처리
         }
@@ -671,8 +671,9 @@ class MemberRepositoryTest {
             entityManager.flush();
 
             // then
-            assertThat(activeMember.isActive()).isTrue(); // 원본 객체는 여전히 활성
-            assertThat(withdrawnMember.isActive()).isFalse(); // 저장된 객체는 비활성
+            assertThat(activeMember.isActive()).isFalse(); // 탈퇴 후 비활성 상태
+            assertThat(withdrawnMember.isActive()).isFalse(); // 저장된 객체도 비활성
+            assertThat(activeMember.getDeletedAt()).isNotNull(); // 탈퇴 시간 설정됨
         }
 
         @Test
@@ -751,7 +752,7 @@ class MemberRepositoryTest {
                         .setParameter("id", m2.getId())
                         .executeUpdate();
                 entityManager.flush();
-            }).isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+            }).isInstanceOf(org.hibernate.exception.ConstraintViolationException.class);
         }
     }
 }

--- a/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
@@ -108,7 +108,7 @@ class MemberServiceImplTest {
         void findById_Success() {
             // given
             Long memberId = 1L;
-            given(memberRepository.findById(memberId))
+            given(memberRepository.findByIdAndIsActiveTrue(memberId))
                     .willReturn(java.util.Optional.of(validMember));
 
             // when
@@ -119,7 +119,7 @@ class MemberServiceImplTest {
             assertThat(result.get().getName()).isEqualTo("홍길동");
             assertThat(result.get().getEmail()).isEqualTo("hong@example.com");
             
-            verify(memberRepository).findById(memberId);
+            verify(memberRepository).findByIdAndIsActiveTrue(memberId);
         }
 
         @Test
@@ -127,14 +127,14 @@ class MemberServiceImplTest {
         void findById_Fail_NotFound() {
             // given
             Long nonExistentId = 999L;
-            given(memberRepository.findById(nonExistentId))
+            given(memberRepository.findByIdAndIsActiveTrue(nonExistentId))
                     .willReturn(java.util.Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> memberService.findById(nonExistentId))
                     .isInstanceOf(MemberHandler.class);
             
-            verify(memberRepository).findById(nonExistentId);
+            verify(memberRepository).findByIdAndIsActiveTrue(nonExistentId);
         }
 
         @Test
@@ -155,7 +155,7 @@ class MemberServiceImplTest {
         void findByEmail_Success() {
             // given
             String email = "hong@example.com";
-            given(memberRepository.findByEmail(email))
+            given(memberRepository.findByEmailAndIsActiveTrue(email))
                     .willReturn(java.util.Optional.of(validMember));
 
             // when
@@ -166,7 +166,7 @@ class MemberServiceImplTest {
             assertThat(result.get().getName()).isEqualTo("홍길동");
             assertThat(result.get().getEmail()).isEqualTo("hong@example.com");
             
-            verify(memberRepository).findByEmail(email);
+            verify(memberRepository).findByEmailAndIsActiveTrue(email);
         }
 
         @Test
@@ -174,14 +174,14 @@ class MemberServiceImplTest {
         void findByEmail_Fail_NotFound() {
             // given
             String nonExistentEmail = "nonexistent@example.com";
-            given(memberRepository.findByEmail(nonExistentEmail))
+            given(memberRepository.findByEmailAndIsActiveTrue(nonExistentEmail))
                     .willReturn(java.util.Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> memberService.findByEmail(nonExistentEmail))
                     .isInstanceOf(MemberHandler.class);
             
-            verify(memberRepository).findByEmail(nonExistentEmail);
+            verify(memberRepository).findByEmailAndIsActiveTrue(nonExistentEmail);
         }
 
         @Test
@@ -218,7 +218,7 @@ class MemberServiceImplTest {
                     .build();
             
             java.util.List<Member> members = java.util.List.of(member1, member2);
-            given(memberRepository.findAll())
+            given(memberRepository.findAllByIsActiveTrue())
                     .willReturn(members);
 
             // when
@@ -229,14 +229,14 @@ class MemberServiceImplTest {
             assertThat(result).extracting(Member::getName).containsExactlyInAnyOrder("홍길동", "김철수");
             assertThat(result).extracting(Member::getEmail).containsExactlyInAnyOrder("hong@example.com", "kim@example.com");
             
-            verify(memberRepository).findAll();
+            verify(memberRepository).findAllByIsActiveTrue();
         }
 
         @Test
         @DisplayName("멤버가 없을 때 모든 멤버 조회 시 빈 리스트 반환")
         void findAll_Empty() {
             // given
-            given(memberRepository.findAll())
+            given(memberRepository.findAllByIsActiveTrue())
                     .willReturn(java.util.List.of());
 
             // when
@@ -245,7 +245,7 @@ class MemberServiceImplTest {
             // then
             assertThat(result).isEmpty();
             
-            verify(memberRepository).findAll();
+            verify(memberRepository).findAllByIsActiveTrue();
         }
 
         @Test
@@ -263,7 +263,7 @@ class MemberServiceImplTest {
                     .build();
             
             java.util.List<Member> members = java.util.List.of(member1, member2);
-            given(memberRepository.findByName(name))
+            given(memberRepository.findByNameAndIsActiveTrue(name))
                     .willReturn(members);
 
             // when
@@ -274,7 +274,7 @@ class MemberServiceImplTest {
             assertThat(result).extracting(Member::getName).containsOnly("홍길동");
             assertThat(result).extracting(Member::getEmail).containsExactlyInAnyOrder("hong1@example.com", "hong2@example.com");
             
-            verify(memberRepository).findByName(name);
+            verify(memberRepository).findByNameAndIsActiveTrue(name);
         }
 
         @Test
@@ -282,7 +282,7 @@ class MemberServiceImplTest {
         void findByName_Fail_NotFound() {
             // given
             String nonExistentName = "존재하지않는이름";
-            given(memberRepository.findByName(nonExistentName))
+            given(memberRepository.findByNameAndIsActiveTrue(nonExistentName))
                     .willReturn(java.util.List.of());
 
             // when
@@ -291,7 +291,7 @@ class MemberServiceImplTest {
             // then
             assertThat(result).isEmpty();
             
-            verify(memberRepository).findByName(nonExistentName);
+            verify(memberRepository).findByNameAndIsActiveTrue(nonExistentName);
         }
 
         @Test
@@ -329,7 +329,7 @@ class MemberServiceImplTest {
         void findById_Fail_RepositoryFailure() {
             // given
             Long memberId = 1L;
-            given(memberRepository.findById(memberId))
+            given(memberRepository.findByIdAndIsActiveTrue(memberId))
                     .willThrow(new RuntimeException("데이터베이스 조회 실패"));
 
             // when & then
@@ -337,7 +337,7 @@ class MemberServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("데이터베이스 조회 실패");
             
-            verify(memberRepository).findById(memberId);
+            verify(memberRepository).findByIdAndIsActiveTrue(memberId);
         }
 
         @Test
@@ -345,7 +345,7 @@ class MemberServiceImplTest {
         void findByEmail_Fail_RepositoryFailure() {
             // given
             String email = "hong@example.com";
-            given(memberRepository.findByEmail(email))
+            given(memberRepository.findByEmailAndIsActiveTrue(email))
                     .willThrow(new RuntimeException("데이터베이스 조회 실패"));
 
             // when & then
@@ -353,14 +353,14 @@ class MemberServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("데이터베이스 조회 실패");
             
-            verify(memberRepository).findByEmail(email);
+            verify(memberRepository).findByEmailAndIsActiveTrue(email);
         }
 
         @Test
         @DisplayName("Repository 조회 실패 시 예외 전파 - findAll")
         void findAll_Fail_RepositoryFailure() {
             // given
-            given(memberRepository.findAll())
+            given(memberRepository.findAllByIsActiveTrue())
                     .willThrow(new RuntimeException("데이터베이스 조회 실패"));
 
             // when & then
@@ -368,7 +368,7 @@ class MemberServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("데이터베이스 조회 실패");
             
-            verify(memberRepository).findAll();
+            verify(memberRepository).findAllByIsActiveTrue();
         }
 
         @Test
@@ -376,7 +376,7 @@ class MemberServiceImplTest {
         void findByName_Fail_RepositoryFailure() {
             // given
             String name = "홍길동";
-            given(memberRepository.findByName(name))
+            given(memberRepository.findByNameAndIsActiveTrue(name))
                     .willThrow(new RuntimeException("데이터베이스 조회 실패"));
 
             // when & then
@@ -384,7 +384,7 @@ class MemberServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("데이터베이스 조회 실패");
             
-            verify(memberRepository).findByName(name);
+            verify(memberRepository).findByNameAndIsActiveTrue(name);
             }
         }
 

--- a/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/member/service/MemberServiceImplTest.java
@@ -602,8 +602,8 @@ class MemberServiceImplTest {
                     .name("홍길동")
                     .email("hong@example.com")
                     .build();
-            // 이미 탈퇴한 상태로 설정 (실제 구현에서는 isActive() 메서드로 확인)
-            // inactiveMember.deactivate(); // 구현 후 활성화
+            // 이미 탈퇴한 상태로 설정
+            inactiveMember.deactivate();
             
             given(memberRepository.findById(memberId))
                     .willReturn(java.util.Optional.of(inactiveMember));
@@ -638,123 +638,6 @@ class MemberServiceImplTest {
             
             verify(memberRepository).findById(memberId);
             verify(memberRepository).save(any(Member.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("탈퇴 회원 제외 조회 테스트")
-    class ExcludeInactiveMembersTest {
-
-        @Test
-        @DisplayName("ID로 조회 시 탈퇴한 회원은 조회되지 않음")
-        void findById_ExcludesInactiveMembers() {
-            // given
-            Long memberId = 1L;
-            Member inactiveMember = Member.builder()
-                    .name("홍길동")
-                    .email("hong@example.com")
-                    .build();
-            // 탈퇴한 상태로 설정 (실제 구현에서는 isActive() 메서드로 확인)
-            // inactiveMember.withdraw();
-            
-            given(memberRepository.findById(memberId))
-                    .willReturn(java.util.Optional.of(inactiveMember));
-
-            // when & then
-            // 실제 구현에서는 탈퇴한 회원에 대해 MEMBER_NOT_FOUND 예외 발생
-            // assertThatThrownBy(() -> memberService.findById(memberId))
-            //         .isInstanceOf(MemberHandler.class);
-            
-            // 현재는 구현되지 않았으므로 주석 처리
-            // 구현 후에는 탈퇴한 회원이 조회되지 않는 것을 검증
-        }
-
-        @Test
-        @DisplayName("이메일로 조회 시 탈퇴한 회원은 조회되지 않음")
-        void findByEmail_ExcludesInactiveMembers() {
-            // given
-            String email = "hong@example.com";
-            Member inactiveMember = Member.builder()
-                    .name("홍길동")
-                    .email(email)
-                    .build();
-            // 탈퇴한 상태로 설정
-            // inactiveMember.deactivate();
-            
-            given(memberRepository.findByEmail(email))
-                    .willReturn(java.util.Optional.of(inactiveMember));
-
-            // when & then
-            // 실제 구현에서는 탈퇴한 회원에 대해 MEMBER_NOT_FOUND 예외 발생
-            // assertThatThrownBy(() -> memberService.findByEmail(email))
-            //         .isInstanceOf(MemberHandler.class);
-            
-            // 현재는 구현되지 않았으므로 주석 처리
-        }
-
-        @Test
-        @DisplayName("이름으로 조회 시 탈퇴한 회원은 제외됨")
-        void findByName_ExcludesInactiveMembers() {
-            // given
-            String name = "홍길동";
-            Member activeMember = Member.builder()
-                    .name(name)
-                    .email("active@example.com")
-                    .build();
-            Member inactiveMember = Member.builder()
-                    .name(name)
-                    .email("inactive@example.com")
-                    .build();
-            // 탈퇴한 상태로 설정
-            // inactiveMember.deactivate();
-            
-            java.util.List<Member> members = java.util.List.of(activeMember);
-            given(memberRepository.findByName(name))
-                    .willReturn(members);
-
-            // when
-            var result = memberService.findByName(name);
-
-            // then
-            // 실제 구현에서는 활성 회원만 조회되어야 함
-            assertThat(result).hasSize(1);
-            assertThat(result).extracting(Member::getEmail).containsOnly("active@example.com");
-            
-            // 현재는 구현되지 않았으므로 주석 처리된 부분이 실제 동작해야 함
-        }
-
-        @Test
-        @DisplayName("전체 조회 시 탈퇴한 회원은 제외됨")
-        void findAll_ExcludesInactiveMembers() {
-            // given
-            Member activeMember1 = Member.builder()
-                    .name("홍길동")
-                    .email("hong1@example.com")
-                    .build();
-            Member activeMember2 = Member.builder()
-                    .name("김철수")
-                    .email("kim@example.com")
-                    .build();
-            Member inactiveMember = Member.builder()
-                    .name("이영희")
-                    .email("lee@example.com")
-                    .build();
-            // 탈퇴한 상태로 설정
-            // inactiveMember.deactivate();
-            
-            java.util.List<Member> activeMembers = java.util.List.of(activeMember1, activeMember2);
-            given(memberRepository.findAll())
-                    .willReturn(activeMembers);
-
-            // when
-            var result = memberService.findAll();
-
-            // then
-            // 실제 구현에서는 활성 회원만 조회되어야 함
-            assertThat(result).hasSize(2);
-            assertThat(result).extracting(Member::getEmail).containsExactlyInAnyOrder("hong1@example.com", "kim@example.com");
-            
-            // 현재는 구현되지 않았으므로 주석 처리된 부분이 실제 동작해야 함
         }
     }
 }


### PR DESCRIPTION

## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

### 관련 이슈
- Close: #26 

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- Member 클래스에 isActive 메서드 및 deactivate 메서드 구현
- MemberServiceImpl 클래스에서 탈퇴한 회원 조회 시 예외 처리 추가
- 관련 테스트 케이스 업데이트 

### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 회원 탈퇴 시 계정이 즉시 비활성화되고 탈퇴 일시가 기록됩니다.
  - 회원 닉네임을 변경하는 API가 추가되었습니다.

- **Bug Fixes**
  - 이미 탈퇴한 회원의 재탈퇴 시도가 차단되고 명확한 오류가 반환됩니다.
  - 비활성 회원은 기본 조회에서 제외되도록 일관되게 적용되었습니다.
  - 비활성 회원에 대한 비밀번호/이메일 변경 시 적절히 차단되고 중복 이메일은 검증 오류로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->