### PR TITLE
[refactor] 로그인 및 리프레시 토큰 기능 개선

### DIFF
--- a/order/src/main/java/com/ipia/order/auth/service/AuthService.java
+++ b/order/src/main/java/com/ipia/order/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.ipia.order.auth.service;
 
 import com.ipia.order.member.domain.Member;
+import com.ipia.order.web.dto.response.auth.LoginResponse;
 
 public interface AuthService {
     
@@ -10,7 +11,7 @@ public interface AuthService {
      * @param password 비밀번호
      * @return JWT 토큰 (임시로 String 반환)
      */
-    String login(String email, String password);
+    // removed legacy login(email,password)
     
     /**
      * 로그아웃
@@ -26,4 +27,19 @@ public interface AuthService {
      * @return 생성된 회원
      */
     Member register(String name, String email, String password);
+
+    /**
+     * 로그인 (Access/Refresh 토큰 발급 포함)
+     * @param email 이메일
+     * @param password 비밀번호
+     * @return 로그인 결과(토큰 및 사용자 정보)
+     */
+    LoginResponse login(String email, String password);
+
+    /**
+     * 리프레시 토큰으로 액세스/리프레시 재발급
+     * @param refreshToken 리프레시 토큰
+     * @return 새 토큰과 사용자 정보
+     */
+    LoginResponse refresh(String refreshToken);
 }

--- a/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
@@ -12,6 +12,7 @@ import com.ipia.order.member.service.MemberService;
 import com.ipia.order.web.dto.request.auth.LoginRequest;
 import com.ipia.order.web.dto.request.auth.RegisterRequest;
 import com.ipia.order.web.dto.request.auth.TokenRequest;
+import com.ipia.order.web.dto.response.MemberResponse;
 import com.ipia.order.web.dto.response.auth.LoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -50,28 +51,8 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
         try {
-            // AuthService를 통한 로그인 처리
-            String accessToken = authService.login(request.getEmail(), request.getPassword());
-            
-            // 토큰에서 사용자 정보 추출
-            Long memberId = jwtUtil.getUserIdFromToken(accessToken);
-            String email = jwtUtil.getEmailFromToken(accessToken);
-            String role = jwtUtil.getRoleFromToken(accessToken);
-            
-            // Refresh Token 생성
-            String refreshToken = jwtUtil.generateRefreshToken(memberId);
-            
-            // 응답 DTO 생성
-            LoginResponse response = new LoginResponse(
-                accessToken,
-                refreshToken,
-                memberId,
-                email,
-                role
-            );
-            
+            LoginResponse response = authService.login(request.getEmail(), request.getPassword());
             return ApiResponse.onSuccess(AuthSuccessStatus.LOGIN_SUCCESS, response);
-            
         } catch (Exception e) {
             return ApiResponse.onFailure(AuthErrorStatus.LOGIN_FAILED, (LoginResponse) null);
         }
@@ -95,10 +76,10 @@ public class AuthController {
             @Valid @RequestBody RegisterRequest request) {
         try {
             Member newMember = authService.register(request.getName(), request.getEmail(), request.getPassword());
-            com.ipia.order.web.dto.response.MemberResponse response = com.ipia.order.web.dto.response.MemberResponse.from(newMember);
+            MemberResponse response = MemberResponse.from(newMember);
             return ApiResponse.onSuccess(AuthSuccessStatus.REGISTER_SUCCESS, response);
         } catch (Exception e) {
-            return ApiResponse.onFailure(AuthErrorStatus.MEMBER_ALREADY_EXISTS, (com.ipia.order.web.dto.response.MemberResponse) null);
+            return ApiResponse.onFailure(AuthErrorStatus.MEMBER_ALREADY_EXISTS, (MemberResponse) null);
         }
     }
 
@@ -141,45 +122,8 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<LoginResponse>> refresh(@Valid @RequestBody TokenRequest request) {
         try {
-            // Refresh Token 검증
-            jwtUtil.validateToken(request.getToken());
-            
-            // 토큰 타입 확인
-            String tokenType = jwtUtil.getTokenType(request.getToken());
-            if (!"REFRESH".equals(tokenType)) {
-                return ApiResponse.onFailure(AuthErrorStatus.INVALID_TOKEN, (LoginResponse) null);
-            }
-            
-            // 토큰에서 사용자 ID 추출
-            Long memberId = jwtUtil.getUserIdFromToken(request.getToken());
-            
-            // 회원 정보 조회
-            Member member = memberService.findById(memberId).orElse(null);
-            if (member == null || !member.isActive()) {
-                return ApiResponse.onFailure(AuthErrorStatus.INACTIVE_MEMBER, (LoginResponse) null);
-            }
-            
-            // 새로운 Access Token 생성
-            String newAccessToken = jwtUtil.generateAccessToken(
-                member.getId(),
-                member.getEmail(),
-                member.getRole().getCode()
-            );
-            
-            // 새로운 Refresh Token 생성
-            String newRefreshToken = jwtUtil.generateRefreshToken(memberId);
-            
-            // 응답 DTO 생성
-            LoginResponse response = new LoginResponse(
-                newAccessToken,
-                newRefreshToken,
-                member.getId(),
-                member.getEmail(),
-                member.getRole().getCode()
-            );
-            
+            LoginResponse response = authService.refresh(request.getToken());
             return ApiResponse.onSuccess(AuthSuccessStatus.TOKEN_REFRESH_SUCCESS, response);
-            
         } catch (Exception e) {
             return ApiResponse.onFailure(AuthErrorStatus.INVALID_TOKEN, (LoginResponse) null);
         }

--- a/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
@@ -124,8 +124,10 @@ public class AuthController {
         try {
             LoginResponse response = authService.refresh(request.getToken());
             return ApiResponse.onSuccess(AuthSuccessStatus.TOKEN_REFRESH_SUCCESS, response);
+        } catch (AuthHandler e) {
+        return ApiResponse.onFailure(e.getStatus(), null);
         } catch (Exception e) {
-            return ApiResponse.onFailure(AuthErrorStatus.INVALID_TOKEN, (LoginResponse) null);
+            return ApiResponse.onFailure(AuthErrorStatus.INVALID_TOKEN, null);
         }
     }
 }


### PR DESCRIPTION

## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

AuthController에서 컨트롤러 계층에서 토큰을 생성하는 등, 컨트롤러에서 책임지지 않는 로직을 담당하고 있어 이를 수정하여 authServiceImpl로 넘겼습니다. 

### 관련 이슈
- Close: #

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- AuthService 인터페이스에 로그인 및 리프레시 메서드 추가: JWT 토큰 발급 및 사용자 정보 반환
- AuthServiceImpl에서 로그인 및 리프레시 로직 구현: 비밀번호 검증, 토큰 생성 및 응답 DTO 구성
- AuthController에서 로그인 및 리프레시 API 수정: 새로운 로그인 및 리프레시 메서드 호출로 변경
- AuthServiceImplTest 및 AuthControllerTest에 로그인 및 리프레시 관련 테스트 케이스 추가
- 
### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [x] 단위/통합 테스트 추가 또는 업데이트
- [x] 로컬에서 기본 시나리오 테스트 완료
- [x] 회귀 영향 구역 점검

### 체크리스트
- [x] 빌드 성공 확인
- [x] 문서/README/주석 업데이트 (필요 시)
- [x] Breaking Change 여부 확인 및 고지
- [x] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - 로그인 시 액세스·리프레시 토큰을 함께 발급하고 이메일 포함 구조화된 응답 제공
  - 리프레시 토큰으로 토큰 재발급(토큰 갱신) 지원

- 버그 수정
  - 잘못된/만료/타입 불일치 토큰 및 비활성 계정 처리 시 일관된 오류 응답 보장

- 리팩터
  - 인증 로직을 서비스로 위임해 컨트롤러 간결화 및 응답 일관성 개선

- 테스트
  - 로그인·리프레시 성공·실패(비밀번호 오류, 계정 없음/비활성, 잘못된 토큰 등) 시나리오 추가 커버리지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->