### PR TITLE
[test] AuthFlowIntegrationTest 인증 플로우 통합 테스트 작성 및 구현 (#41)

### DIFF
--- a/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.ipia.order.auth.service.AuthService;
 import com.ipia.order.common.exception.ApiErrorCodeExample;
 import com.ipia.order.common.exception.ApiErrorCodeExamples;
 import com.ipia.order.common.exception.ApiResponse;
+import com.ipia.order.common.exception.auth.AuthHandler;
 import com.ipia.order.common.exception.auth.status.AuthErrorStatus;
 import com.ipia.order.common.exception.auth.status.AuthSuccessStatus;
 import com.ipia.order.common.util.JwtUtil;

--- a/order/src/test/java/com/ipia/order/web/controller/auth/AuthFlowIntegrationTest.java
+++ b/order/src/test/java/com/ipia/order/web/controller/auth/AuthFlowIntegrationTest.java
@@ -1,0 +1,180 @@
+package com.ipia.order.web.controller.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+@DisplayName("인증 플로우 통합 테스트")
+class AuthFlowIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private void register(String name, String email, String password) throws Exception {
+        String body = String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\"}", name, email, password);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("AUTH2004"));
+    }
+
+    private Tokens loginAndGetTokens(String email, String password) throws Exception {
+        String body = String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+        String response = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("AUTH2001"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        String accessToken = root.path("data").path("accessToken").asText();
+        String refreshToken = root.path("data").path("refreshToken").asText();
+        return new Tokens(accessToken, refreshToken);
+    }
+
+    private Tokens refreshAndGetTokens(String refreshToken) throws Exception {
+        String body = String.format("{\"token\":\"%s\"}", refreshToken);
+        String response = mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("AUTH2003"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(response);
+        String access = root.path("data").path("accessToken").asText();
+        String refresh = root.path("data").path("refreshToken").asText();
+        return new Tokens(access, refresh);
+    }
+
+    @Test
+    @DisplayName("회원가입 → 로그인 → 로그아웃 해피패스")
+    void signup_login_logout_happy_path() throws Exception {
+        String email = "flow@example.com";
+        String password = "Passw0rd!";
+
+        // 회원가입
+        register("홍길동", email, password);
+
+        // 로그인 (토큰 획득)
+        Tokens tokens = loginAndGetTokens(email, password);
+
+        // 로그아웃
+        String logoutBody = String.format("{\"token\":\"%s\"}", tokens.accessToken);
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(logoutBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("AUTH2002"));
+    }
+
+    @Test
+    @DisplayName("중복 이메일 회원가입 409")
+    void register_duplicate_email_409() throws Exception {
+        String email = "dupe@example.com";
+        String password = "Passw0rd!";
+
+        register("홍길동", email, password);
+
+        String dupBody = String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\"}", "홍길동", email, password);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(dupBody))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH4007"));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 재발급 성공")
+    void refresh_token_success() throws Exception {
+        String email = "refreshsuccess@example.com";
+        String password = "Passw0rd!";
+
+        register("홍길동", email, password);
+        Tokens tokens = loginAndGetTokens(email, password);
+
+        Tokens refreshed = refreshAndGetTokens(tokens.refreshToken);
+        assert !refreshed.accessToken().isBlank();
+        assert !refreshed.refreshToken().isBlank();
+    }
+
+    @Test
+    @DisplayName("무효 리프레시 토큰 재발급 401")
+    void refresh_token_invalid_401() throws Exception {
+        String body = "{\"token\":\"invalid-refresh-token\"}";
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH4002"));
+    }
+
+    @Test
+    @DisplayName("ACCESS 토큰으로 재발급 요청 시 401")
+    void refresh_with_access_token_401() throws Exception {
+        String email = "accessasrefresh@example.com";
+        String password = "Passw0rd!";
+
+        register("홍길동", email, password);
+        Tokens tokens = loginAndGetTokens(email, password);
+
+        String body = String.format("{\"token\":\"%s\"}", tokens.accessToken);
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH4002"));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 로그아웃 요청 시 401")
+    void logout_with_refresh_token_401() throws Exception {
+        String email = "logoutrefresh@example.com";
+        String password = "Passw0rd!";
+
+        register("홍길동", email, password);
+        Tokens tokens = loginAndGetTokens(email, password);
+
+        String logoutBody = String.format("{\"token\":\"%s\"}", tokens.refreshToken);
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(logoutBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH4002"));
+    }
+
+    private record Tokens(String accessToken, String refreshToken) {}
+}
+
+


### PR DESCRIPTION
## PR 제목

feat: 인증 플로우 통합 테스트 추가 및 보완 (#41)

---

### 요약
- 회원가입 → 로그인 → 로그아웃 → 리프레시 재발급의 통합 시나리오를 `@SpringBootTest + MockMvc(addFilters=false)`로 검증하는 테스트를 추가했습니다.

### 관련 이슈
- Close: #TBD

### 변경 사항
- 테스트 추가: `order/src/test/java/com/ipia/order/web/controller/auth/AuthFlowIntegrationTest.java`
  - 회원가입 → 로그인 → 로그아웃 해피패스: 200/AUTH2002
  - 중복 이메일 회원가입: 409/AUTH4007
  - 리프레시 토큰 재발급 성공: 200/AUTH2003
  - 무효 리프레시 토큰: 401/AUTH4002
  - ACCESS 토큰으로 재발급 요청: 401/AUTH4002
  - 리프레시 토큰으로 로그아웃 요청: 401/AUTH4002

- API/스키마 변경: 없음

### 스크린샷/로그 (선택)
- Gradle 테스트: BUILD SUCCESSFUL

### 테스트
- [x] 단위/통합 테스트 추가 또는 업데이트
- [x] 로컬에서 기본 시나리오 테스트 완료
- [x] 회귀 영향 구역 점검

### 체크리스트
- [x] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [x] Breaking Change 여부 확인 (없음)
- [x] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 이번 통합 테스트는 보안 체인 개입 없이 컨트롤러-서비스-리포지토리 협력과 토큰 발급/검증 로직을 빠르고 결정적으로 검증하기 위해 `addFilters=false`를 사용했습니다. 보안 흐름(E2E 인가/필터 체인 검증)은 별도 테스트로 분리하는 것을 권장합니다.
- 고려 사항(추후 리팩토링): Redis 도입을 통한 토큰 블랙리스트(Access/Refresh) 저장 및 확인 로직을 추가하고, 로그아웃 이후 동일 토큰/리프레시 재발급 차단 시나리오를 보안 통합 테스트(`addFilters=true`)로 검증할 예정입니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 테스트
  - 인증 흐름(회원가입, 로그인, 토큰 갱신, 로그아웃) 통합 테스트 추가. 정상·오류 시나리오(중복 이메일, 잘못된/엑세스 토큰 사용 등)와 응답 코드 검증을 포함해 안정성과 회귀 방지 강화.

- Chores
  - 내부 의존성 정리(임포트 추가)만 수행되었으며 동작이나 사용자에게 보이는 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->