### PR TITLE
[test] Order 엔티티 비즈니스 로직 실패 테스트 추가 (TDD Red 단계) (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ out/
 
 # Cursor
 .cursor/
+docs/

--- a/order/src/main/java/com/ipia/order/common/exception/order/OrderHandler.java
+++ b/order/src/main/java/com/ipia/order/common/exception/order/OrderHandler.java
@@ -1,0 +1,11 @@
+package com.ipia.order.common.exception.order;
+
+
+import com.ipia.order.common.exception.general.GeneralException;
+import com.ipia.order.common.exception.order.status.OrderErrorStatus;
+
+public class OrderHandler extends GeneralException {
+    public OrderHandler(OrderErrorStatus status) {
+        super(status);
+    }
+}

--- a/order/src/main/java/com/ipia/order/common/exception/order/status/OrderErrorStatus.java
+++ b/order/src/main/java/com/ipia/order/common/exception/order/status/OrderErrorStatus.java
@@ -1,0 +1,67 @@
+package com.ipia.order.common.exception.order.status;
+
+
+
+import org.springframework.http.HttpStatus;
+
+import com.ipia.order.common.exception.ExplainError;
+import com.ipia.order.common.exception.general.status.ErrorResponse;
+
+public enum OrderErrorStatus implements ErrorResponse {
+
+    // 주문
+    @ExplainError("주문을 찾을 수 없음")
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4001", "주문을 찾을 수 없습니다."),
+    @ExplainError("이미 취소된 주문")
+    ORDER_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "ORDER4002", "이미 취소된 주문입니다."),
+    @ExplainError("이미 완료된 주문")
+    ORDER_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "ORDER4003", "이미 완료된 주문입니다."),
+    @ExplainError("이미 결제된 주문")
+    ORDER_ALREADY_PAID(HttpStatus.BAD_REQUEST, "ORDER4004", "이미 결제된 주문입니다."),
+
+    // 주문 생성 관련
+    @ExplainError("유효하지 않은 주문 금액")
+    INVALID_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "ORDER4005", "주문 금액은 0보다 커야 합니다."),
+    @ExplainError("주문 금액이 음수")
+    NEGATIVE_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "ORDER4006", "주문 금액은 음수일 수 없습니다."),
+    @ExplainError("회원 ID가 필수 아님")
+    MEMBER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "ORDER4007", "회원 ID는 필수입니다."),
+
+    // 주문 상태 전이 관련
+    @ExplainError("잘못된 주문 상태 전이 - 결제 완료")
+    INVALID_TRANSITION_TO_PAID(HttpStatus.BAD_REQUEST, "ORDER4008", "현재 상태에서 결제 완료로 전이할 수 없습니다."),
+    @ExplainError("잘못된 주문 상태 전이 - 취소")
+    INVALID_TRANSITION_TO_CANCELED(HttpStatus.BAD_REQUEST, "ORDER4009", "현재 상태에서 취소로 전이할 수 없습니다."),
+    @ExplainError("잘못된 주문 상태 전이 - 완료")
+    INVALID_TRANSITION_TO_COMPLETED(HttpStatus.BAD_REQUEST, "ORDER4010", "현재 상태에서 완료로 전이할 수 없습니다."),
+
+    // 입력값 검증 관련
+    @ExplainError("주문 ID가 필수 아님")
+    ORDER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "ORDER4011", "주문 ID는 필수입니다."),
+    @ExplainError("주문 상태가 필수 아님")
+    ORDER_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "ORDER4012", "주문 상태는 필수입니다."),
+    @ExplainError("유효하지 않은 주문 상태")
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER4013", "유효하지 않은 주문 상태입니다.");
+
+
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    OrderErrorStatus(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getErrorStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/order/src/main/java/com/ipia/order/common/exception/order/status/OrderSuccessStatus.java
+++ b/order/src/main/java/com/ipia/order/common/exception/order/status/OrderSuccessStatus.java
@@ -1,0 +1,46 @@
+package com.ipia.order.common.exception.order.status;
+
+
+
+import org.springframework.http.HttpStatus;
+
+import com.ipia.order.common.exception.general.status.SuccessResponse;
+
+public enum OrderSuccessStatus implements SuccessResponse {
+
+    // 주문 생성
+    ORDER_CREATED(HttpStatus.CREATED, "ORDER2001", "주문이 성공적으로 생성되었습니다."),
+    
+    // 주문 조회
+    ORDER_FOUND(HttpStatus.OK, "ORDER2002", "주문 정보를 성공적으로 조회했습니다."),
+    ORDERS_FOUND(HttpStatus.OK, "ORDER2003", "주문 목록을 성공적으로 조회했습니다."),
+    
+    // 주문 상태 변경
+    ORDER_PAID(HttpStatus.OK, "ORDER2004", "주문 결제가 완료되었습니다."),
+    ORDER_CANCELED(HttpStatus.OK, "ORDER2005", "주문이 성공적으로 취소되었습니다."),
+    ORDER_COMPLETED(HttpStatus.OK, "ORDER2006", "주문이 성공적으로 완료되었습니다."),
+    
+    // 주문 수정
+    ORDER_UPDATED(HttpStatus.OK, "ORDER2007", "주문 정보가 성공적으로 수정되었습니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    OrderSuccessStatus(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getSuccessStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/order/src/main/java/com/ipia/order/order/domain/Order.java
+++ b/order/src/main/java/com/ipia/order/order/domain/Order.java
@@ -1,0 +1,66 @@
+package com.ipia.order.order.domain;
+
+import com.ipia.order.common.entity.BaseEntity;
+import com.ipia.order.common.exception.order.OrderHandler;
+import com.ipia.order.common.exception.order.status.OrderErrorStatus;
+import com.ipia.order.order.enums.OrderStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "total_amount", nullable = false)
+    private Long totalAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OrderStatus status = OrderStatus.PENDING;
+
+    @Builder
+    private Order(Long memberId, Long totalAmount) {
+        this.memberId = memberId;
+        this.totalAmount = totalAmount;
+    }
+
+    public static Order create(Long memberId, Long totalAmount) {
+        return Order.builder()
+                .memberId(memberId)
+                .totalAmount(totalAmount)
+                .build();
+    }
+
+    public void transitionToPaid() {
+        this.status = OrderStatus.PAID;
+    }
+
+    public void transitionToCanceled() {
+        this.status = OrderStatus.CANCELED;
+    }
+
+    public void transitionToCompleted() {
+        this.status = OrderStatus.COMPLETED;
+    }
+
+}

--- a/order/src/main/java/com/ipia/order/order/enums/OrderStatus.java
+++ b/order/src/main/java/com/ipia/order/order/enums/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.ipia.order.order.enums;
+
+public enum OrderStatus {
+    PENDING,    // 대기 중
+    PAID,       // 결제 완료
+    CANCELED,   // 취소됨
+    COMPLETED   // 완료됨
+}

--- a/order/src/test/java/com/ipia/order/order/domain/OrderTest.java
+++ b/order/src/test/java/com/ipia/order/order/domain/OrderTest.java
@@ -1,0 +1,131 @@
+package com.ipia.order.order.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ipia.order.common.exception.order.OrderHandler;
+import com.ipia.order.common.exception.order.status.OrderErrorStatus;
+
+class OrderTest {
+
+    @Test
+    @DisplayName("주문 생성 시 음수 금액이면 예외가 발생한다")
+    void createOrderWithNegativeAmount() {
+        // given
+        Long memberId = 1L;
+        Long negativeAmount = -1000L;
+
+        // when & then
+        assertThatThrownBy(() -> Order.create(memberId, negativeAmount))
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.NEGATIVE_ORDER_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("주문 생성 시 0원이면 예외가 발생한다")
+    void createOrderWithZeroAmount() {
+        // given
+        Long memberId = 1L;
+        Long zeroAmount = 0L;
+
+        // when & then
+        assertThatThrownBy(() -> Order.create(memberId, zeroAmount))
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_ORDER_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("주문 생성 시 회원 ID가 null이면 예외가 발생한다")
+    void createOrderWithNullMemberId() {
+        // given
+        Long memberId = null;
+        Long amount = 1000L;
+
+        // when & then
+        assertThatThrownBy(() -> Order.create(memberId, amount))
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.MEMBER_ID_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("이미 결제된 주문에서 다시 결제 완료로 전이하면 예외가 발생한다")
+    void transitionToPaidFromAlreadyPaidOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToPaid(); // 이미 결제 완료 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToPaid())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_PAID);
+    }
+
+    @Test
+    @DisplayName("이미 취소된 주문에서 결제 완료로 전이하면 예외가 발생한다")
+    void transitionToPaidFromCanceledOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToCanceled(); // 취소 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToPaid())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_PAID);
+    }
+
+    @Test
+    @DisplayName("이미 완료된 주문에서 결제 완료로 전이하면 예외가 발생한다")
+    void transitionToPaidFromCompletedOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToPaid();
+        order.transitionToCompleted(); // 완료 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToPaid())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_PAID);
+    }
+
+    @Test
+    @DisplayName("이미 취소된 주문에서 다시 취소로 전이하면 예외가 발생한다")
+    void transitionToCanceledFromAlreadyCanceledOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToCanceled(); // 이미 취소 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToCanceled())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_CANCELED);
+    }
+
+    @Test
+    @DisplayName("이미 완료된 주문에서 취소로 전이하면 예외가 발생한다")
+    void transitionToCanceledFromCompletedOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToPaid();
+        order.transitionToCompleted(); // 완료 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToCanceled())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_CANCELED);
+    }
+
+    @Test
+    @DisplayName("이미 결제된 주문에서 취소로 전이하면 예외가 발생한다")
+    void transitionToCanceledFromPaidOrder() {
+        // given
+        Order order = Order.create(1L, 1000L);
+        order.transitionToPaid(); // 결제 완료 상태
+
+        // when & then
+        assertThatThrownBy(() -> order.transitionToCanceled())
+                .isInstanceOf(OrderHandler.class)
+                .hasFieldOrPropertyWithValue("status", OrderErrorStatus.INVALID_TRANSITION_TO_CANCELED);
+    }
+}


### PR DESCRIPTION
### 요약
- Order 엔티티의 핵심 비즈니스 로직에 대한 실패 케이스 테스트를 TDD Red 단계로 작성했습니다.
- 주문 생성 시 검증 로직과 상태 전이 로직의 예외 처리를 검증하는 테스트를 구현했습니다.
- **9개의 테스트가 모두 실패**하여 TDD Red 단계가 성공적으로 완료되었습니다.

### 관련 이슈
- Close: #46 

### 변경 사항
- **Order 도메인 구조 생성**:
  - `Order` 엔티티 클래스 추가 (JPA 엔티티, 기본 구조만)
  - `OrderStatus` enum 추가 (PENDING, PAID, CANCELED, COMPLETED)
  - `OrderHandler` 예외 처리 클래스 추가
  - `OrderErrorStatus` 및 `OrderSuccessStatus` enum 추가

- **기본 비즈니스 로직 구현** (검증 로직 없음):
  - `Order.create(memberId, totalAmount)` - 주문 생성 (검증 없음)
  - `Order.transitionToPaid()` - 결제 완료 상태 전이 (검증 없음)
  - `Order.transitionToCanceled()` - 취소 상태 전이 (검증 없음)
  - `Order.transitionToCompleted()` - 완료 상태 전이 (검증 없음)

- **실패 테스트 케이스 작성** (9개):
  - 음수/0원 금액 검증 테스트
  - null 회원 ID 검증 테스트
  - 잘못된 상태에서 결제 완료 전이 테스트 (이미 결제됨, 취소됨, 완료됨)
  - 잘못된 상태에서 취소 전이 테스트 (이미 취소됨, 완료됨, 결제됨)

### 스크린샷/로그 (선택)
```
9 tests completed, 9 failed

FAILURE: Build failed with a exception.
* There were failing tests.
```
- **TDD Red 단계 완료**: 모든 테스트가 예상대로 실패함을 확인

### 테스트
- [x] 단위 테스트 추가 또는 업데이트
- [x] 로컬에서 기본 시나리오 테스트 완료 (실패 확인)
- [x] 회귀 영향 구역 점검

### 체크리스트
- [x] 빌드 성공 확인 (테스트 실패로 인한 빌드 실패는 의도된 결과)
- [x] 문서/README/주석 업데이트 (필요 시)
- [x] Breaking Change 여부 확인 및 고지
- [x] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- **TDD Red 단계 완료**: 9개의 테스트가 모두 실패하여 예상대로 동작함을 확인했습니다.
- Order 엔티티는 Member 엔티티와 동일한 패턴으로 구현하여 일관성을 유지했습니다.
- 예외 처리는 커스텀 `OrderHandler`를 통해 비즈니스 로직과 분리하여 관리합니다.
- **다음 단계**: TDD Green 단계로, 테스트를 통과시키는 최소한의 검증 로직 구현 예정
- 현재 Order 엔티티에는 검증 로직이 없어 모든 테스트가 실패하는 상태입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 주문 엔티티와 상태(PENDING/PAID/CANCELED/COMPLETED) 도입으로 주문 수명주기 관리가 가능해졌습니다.
  - 주문 생성·결제·취소·완료 시 표준화된 성공/오류 응답을 제공합니다(상태 코드·메시지 일원화).
- 테스트
  - 주문 생성 유효성 및 상태 전이 예외 흐름에 대한 단위 테스트를 추가했습니다.
- Chores
  - docs/ 디렉터리를 버전 관리에서 제외하여 불필요한 파일 추적을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->