### PR TITLE
[test] OrderService 실패 케이스 테스트 작성 (#51)

### DIFF
--- a/order/src/main/java/com/ipia/order/common/exception/order/status/OrderErrorStatus.java
+++ b/order/src/main/java/com/ipia/order/common/exception/order/status/OrderErrorStatus.java
@@ -41,7 +41,29 @@ public enum OrderErrorStatus implements ErrorResponse {
     @ExplainError("주문 상태가 필수 아님")
     ORDER_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "ORDER4012", "주문 상태는 필수입니다."),
     @ExplainError("유효하지 않은 주문 상태")
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER4013", "유효하지 않은 주문 상태입니다.");
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER4013", "유효하지 않은 주문 상태입니다."),
+
+    // OrderService 관련 추가 예외들
+    @ExplainError("존재하지 않는 회원")
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER4014", "존재하지 않는 회원입니다."),
+    @ExplainError("비활성 회원")
+    INACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "ORDER4015", "비활성 회원입니다."),
+    @ExplainError("유효하지 않은 주문 금액")
+    INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "ORDER4016", "주문 금액은 0보다 커야 합니다."),
+    @ExplainError("멱등 키 충돌")
+    IDEMPOTENCY_CONFLICT(HttpStatus.CONFLICT, "ORDER4017", "동일한 멱등 키로 이미 처리된 요청입니다."),
+    @ExplainError("권한 없는 주문 조회")
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER4018", "해당 주문에 대한 접근 권한이 없습니다."),
+    @ExplainError("잘못된 필터 조건")
+    INVALID_FILTER(HttpStatus.BAD_REQUEST, "ORDER4019", "잘못된 필터 조건입니다."),
+    @ExplainError("잘못된 페이지네이션 파라미터")
+    INVALID_PAGINATION(HttpStatus.BAD_REQUEST, "ORDER4020", "잘못된 페이지네이션 파라미터입니다."),
+    @ExplainError("잘못된 주문 상태")
+    INVALID_ORDER_STATE(HttpStatus.BAD_REQUEST, "ORDER4021", "잘못된 주문 상태입니다."),
+    @ExplainError("이미 취소된 주문")
+    ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "ORDER4022", "이미 취소된 주문입니다."),
+    @ExplainError("중복 승인 시도")
+    DUPLICATE_APPROVAL(HttpStatus.CONFLICT, "ORDER4023", "이미 승인된 주문입니다.");
 
 
 

--- a/order/src/main/java/com/ipia/order/order/domain/Order.java
+++ b/order/src/main/java/com/ipia/order/order/domain/Order.java
@@ -88,4 +88,46 @@ public class Order extends BaseEntity {
             throw new OrderHandler(errorOnMismatch);
         }
     }
+
+    /**
+     * 테스트용 Order 생성 (Reflection 사용)
+     * @param id 주문 ID
+     * @param memberId 회원 ID
+     * @param totalAmount 주문 총액
+     * @param status 주문 상태
+     * @return 테스트용 Order 객체
+     */
+    public static Order createTestOrder(Long id, Long memberId, Long totalAmount, OrderStatus status) {
+        Order order = Order.builder()
+                .memberId(memberId)
+                .totalAmount(totalAmount)
+                .build();
+        
+        // Reflection을 사용하여 필드 설정
+        try {
+            // ID 필드 설정
+            java.lang.reflect.Field idField = Order.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(order, id);
+            
+            // status 필드 설정
+            java.lang.reflect.Field statusField = Order.class.getDeclaredField("status");
+            statusField.setAccessible(true);
+            statusField.set(order, status);
+            
+            // createdAt 필드 설정
+            java.lang.reflect.Field createdAtField = Order.class.getSuperclass().getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(order, java.time.LocalDateTime.now());
+            
+            // updatedAt 필드 설정
+            java.lang.reflect.Field updatedAtField = Order.class.getSuperclass().getDeclaredField("updatedAt");
+            updatedAtField.setAccessible(true);
+            updatedAtField.set(order, java.time.LocalDateTime.now());
+        } catch (Exception e) {
+            throw new RuntimeException("테스트용 Order 생성 실패", e);
+        }
+        
+        return order;
+    }
 }

--- a/order/src/main/java/com/ipia/order/order/event/PaymentApprovedEvent.java
+++ b/order/src/main/java/com/ipia/order/order/event/PaymentApprovedEvent.java
@@ -1,0 +1,49 @@
+package com.ipia.order.order.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 결제 승인 이벤트
+ * 
+ * 결제 도메인에서 주문 도메인으로 발행하는 이벤트
+ */
+@Getter
+@AllArgsConstructor
+public class PaymentApprovedEvent {
+    
+    /**
+     * 주문 ID
+     */
+    private final Long orderId;
+    
+    /**
+     * 결제 승인 금액
+     */
+    private final BigDecimal paidAmount;
+    
+    /**
+     * 결제 승인 일시
+     */
+    private final LocalDateTime approvedAt;
+    
+    /**
+     * 결제 제공업체 거래 ID (선택사항)
+     */
+    private final String providerTransactionId;
+    
+    /**
+     * 결제 승인 이벤트 생성
+     * 
+     * @param orderId 주문 ID
+     * @param paidAmount 결제 승인 금액
+     * @param providerTransactionId 결제 제공업체 거래 ID
+     * @return 결제 승인 이벤트
+     */
+    public static PaymentApprovedEvent of(Long orderId, BigDecimal paidAmount, String providerTransactionId) {
+        return new PaymentApprovedEvent(orderId, paidAmount, LocalDateTime.now(), providerTransactionId);
+    }
+}

--- a/order/src/main/java/com/ipia/order/order/event/PaymentCanceledEvent.java
+++ b/order/src/main/java/com/ipia/order/order/event/PaymentCanceledEvent.java
@@ -1,0 +1,55 @@
+package com.ipia.order.order.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 결제 취소 이벤트
+ * 
+ * 결제 도메인에서 주문 도메인으로 발행하는 이벤트
+ */
+@Getter
+@AllArgsConstructor
+public class PaymentCanceledEvent {
+    
+    /**
+     * 주문 ID
+     */
+    private final Long orderId;
+    
+    /**
+     * 취소 금액
+     */
+    private final BigDecimal canceledAmount;
+    
+    /**
+     * 취소 일시
+     */
+    private final LocalDateTime canceledAt;
+    
+    /**
+     * 취소 사유 (선택사항)
+     */
+    private final String reason;
+    
+    /**
+     * 결제 제공업체 거래 ID (선택사항)
+     */
+    private final String providerTransactionId;
+    
+    /**
+     * 결제 취소 이벤트 생성
+     * 
+     * @param orderId 주문 ID
+     * @param canceledAmount 취소 금액
+     * @param reason 취소 사유
+     * @param providerTransactionId 결제 제공업체 거래 ID
+     * @return 결제 취소 이벤트
+     */
+    public static PaymentCanceledEvent of(Long orderId, BigDecimal canceledAmount, String reason, String providerTransactionId) {
+        return new PaymentCanceledEvent(orderId, canceledAmount, LocalDateTime.now(), reason, providerTransactionId);
+    }
+}

--- a/order/src/main/java/com/ipia/order/order/repository/OrderRepository.java
+++ b/order/src/main/java/com/ipia/order/order/repository/OrderRepository.java
@@ -1,0 +1,62 @@
+package com.ipia.order.order.repository;
+
+import com.ipia.order.order.domain.Order;
+import com.ipia.order.order.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 주문 리포지토리
+ */
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    
+    /**
+     * 회원 ID와 상태로 주문 조회 (페이지네이션)
+     * 
+     * @param memberId 회원 ID
+     * @param status 주문 상태
+     * @param pageable 페이지네이션 정보
+     * @return 주문 목록
+     */
+    Page<Order> findByMemberIdAndStatus(Long memberId, OrderStatus status, Pageable pageable);
+    
+    /**
+     * 회원 ID로 주문 조회 (페이지네이션)
+     * 
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 주문 목록
+     */
+    Page<Order> findByMemberId(Long memberId, Pageable pageable);
+    
+    /**
+     * 상태로 주문 조회 (페이지네이션)
+     * 
+     * @param status 주문 상태
+     * @param pageable 페이지네이션 정보
+     * @return 주문 목록
+     */
+    Page<Order> findByStatus(OrderStatus status, Pageable pageable);
+    
+    /**
+     * 회원 ID로 주문 목록 조회
+     * 
+     * @param memberId 회원 ID
+     * @return 주문 목록
+     */
+    List<Order> findByMemberId(Long memberId);
+    
+    /**
+     * 상태로 주문 목록 조회
+     * 
+     * @param status 주문 상태
+     * @return 주문 목록
+     */
+    List<Order> findByStatus(OrderStatus status);
+}

--- a/order/src/main/java/com/ipia/order/order/service/OrderService.java
+++ b/order/src/main/java/com/ipia/order/order/service/OrderService.java
@@ -1,0 +1,90 @@
+package com.ipia.order.order.service;
+
+import com.ipia.order.order.domain.Order;
+import com.ipia.order.order.enums.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 주문 서비스 인터페이스
+ * 
+ * 주요 기능:
+ * - 주문 생성 (멱등성 지원)
+ * - 주문 조회 (단건/목록)
+ * - 주문 취소 (비즈니스 취소)
+ * - 결제 이벤트 핸들링
+ */
+public interface OrderService {
+    
+    /**
+     * 주문 생성
+     * 
+     * @param memberId 회원 ID
+     * @param totalAmount 주문 총액 (0보다 커야 함)
+     * @param idempotencyKey 멱등성 키 (선택사항)
+     * @return 생성된 주문
+     * @throws MemberNotFoundException 존재하지 않는 회원
+     * @throws InvalidAmountException 음수 또는 0원 주문 금액
+     * @throws InactiveMemberException 비활성 회원
+     * @throws IdempotencyConflictException 멱등 키 중복
+     */
+    Order createOrder(long memberId, long totalAmount, @Nullable String idempotencyKey);
+    
+    /**
+     * 주문 단건 조회
+     * 
+     * @param orderId 주문 ID
+     * @return 주문 정보 (없으면 Optional.empty())
+     * @throws OrderNotFoundException 존재하지 않는 주문
+     * @throws AccessDeniedException 권한 없는 주문 조회
+     */
+    Optional<Order> getOrder(long orderId);
+    
+    /**
+     * 주문 목록 조회 (페이지네이션)
+     * 
+     * @param memberId 회원 ID (선택사항)
+     * @param status 주문 상태 (선택사항)
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 페이지 크기
+     * @return 주문 목록
+     * @throws InvalidFilterException 잘못된 필터 조건
+     * @throws InvalidPaginationException 잘못된 페이지네이션 파라미터
+     */
+    List<Order> listOrders(@Nullable Long memberId, @Nullable OrderStatus status, int page, int size);
+    
+    /**
+     * 주문 취소 (비즈니스 취소)
+     * 
+     * @param orderId 주문 ID
+     * @param reason 취소 사유 (선택사항)
+     * @return 취소된 주문
+     * @throws OrderNotFoundException 존재하지 않는 주문
+     * @throws InvalidOrderStateException 잘못된 상태에서 취소 시도
+     * @throws AlreadyCanceledException 이미 취소된 주문
+     * @throws IdempotencyConflictException 멱등 키 중복
+     */
+    Order cancelOrder(long orderId, @Nullable String reason);
+    
+    /**
+     * 결제 승인 이벤트 핸들링
+     * 
+     * @param orderId 주문 ID
+     * @throws OrderNotFoundException 존재하지 않는 주문
+     * @throws InvalidOrderStateException 잘못된 상태에서 승인 시도
+     * @throws DuplicateApprovalException 중복 승인 시도
+     */
+    void handlePaymentApproved(long orderId);
+    
+    /**
+     * 결제 취소 이벤트 핸들링
+     * 
+     * @param orderId 주문 ID
+     * @throws OrderNotFoundException 존재하지 않는 주문
+     * @throws InvalidOrderStateException 잘못된 상태에서 취소 시도
+     */
+    void handlePaymentCanceled(long orderId);
+}

--- a/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
@@ -1,0 +1,70 @@
+package com.ipia.order.order.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ipia.order.member.service.MemberService;
+import com.ipia.order.order.domain.Order;
+import com.ipia.order.order.enums.OrderStatus;
+import com.ipia.order.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 주문 서비스 구현체
+ * 
+ * TODO: TDD Green 단계에서 구현 예정
+ * 현재는 테스트 컴파일을 위한 스텁 구현
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+    private final MemberService memberService;
+    // TODO: IdempotencyKeyService 의존성 추가 (Phase 2 후반에 구현)
+
+    @Override
+    @Transactional
+    public Order createOrder(long memberId, long totalAmount, String idempotencyKey) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Optional<Order> getOrder(long orderId) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public List<Order> listOrders(Long memberId, OrderStatus status, int page, int size) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    @Transactional
+    public Order cancelOrder(long orderId, String reason) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    @Transactional
+    public void handlePaymentApproved(long orderId) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    @Transactional
+    public void handlePaymentCanceled(long orderId) {
+        // TODO: TDD Green 단계에서 구현
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/order/src/test/java/com/ipia/order/order/service/OrderServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/order/service/OrderServiceImplTest.java
@@ -1,0 +1,419 @@
+package com.ipia.order.order.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ipia.order.member.domain.Member;
+import com.ipia.order.member.service.MemberService;
+import com.ipia.order.order.domain.Order;
+import com.ipia.order.order.enums.OrderStatus;
+import com.ipia.order.order.repository.OrderRepository;
+import com.ipia.order.common.exception.order.OrderHandler;
+import com.ipia.order.common.exception.order.status.OrderErrorStatus;
+
+import java.util.Optional;
+
+/**
+ * OrderService 실패 케이스 테스트
+ * 
+ * TDD Red 단계: 모든 테스트는 먼저 실패해야 함
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderService 실패 케이스 테스트")
+class OrderServiceImplTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+    
+    @Mock
+    private MemberService memberService;
+    
+    // TODO: IdempotencyKeyService Mock 추가 (Phase 2 후반에 구현 예정)
+    
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    private Member validMember;
+    private Order validOrder;
+
+    @BeforeEach
+    void setUp() {
+        validMember = Member.createTestMember(1L, "홍길동", "hong@example.com", "encodedPassword123!", null);
+
+        validOrder = Order.createTestOrder(1L, 1L, 10000L, OrderStatus.PENDING);
+    }
+
+    @Nested
+    @DisplayName("createOrder 실패 케이스")
+    class CreateOrderFailureTest {
+
+        @Test
+        @DisplayName("존재하지 않는 회원으로 주문 생성 시 MemberNotFoundException 발생")
+        void createOrder_WithNonExistentMember_ThrowsMemberNotFoundException() {
+            // given
+            long nonExistentMemberId = 999L;
+            long totalAmount = 10000L;
+            String idempotencyKey = "test-key";
+
+            given(memberService.findById(nonExistentMemberId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.createOrder(nonExistentMemberId, totalAmount, idempotencyKey))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("비활성 회원으로 주문 생성 시 InactiveMemberException 발생")
+        void createOrder_WithInactiveMember_ThrowsInactiveMemberException() {
+            // given
+            long memberId = 1L;
+            long totalAmount = 10000L;
+            String idempotencyKey = "test-key";
+
+            Member inactiveMember = Member.createTestMember(memberId, "홍길동", "hong@example.com", "encodedPassword123!", null);
+            // 비활성 회원으로 설정
+            try {
+                java.lang.reflect.Field isActiveField = Member.class.getDeclaredField("isActive");
+                isActiveField.setAccessible(true);
+                isActiveField.set(inactiveMember, false);
+            } catch (Exception e) {
+                throw new RuntimeException("비활성 회원 설정 실패", e);
+            }
+
+            given(memberService.findById(memberId))
+                    .willReturn(Optional.of(inactiveMember));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.createOrder(memberId, totalAmount, idempotencyKey))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INACTIVE_MEMBER.getMessage());
+        }
+
+        @Test
+        @DisplayName("음수 금액으로 주문 생성 시 InvalidAmountException 발생")
+        void createOrder_WithNegativeAmount_ThrowsInvalidAmountException() {
+            // given
+            long memberId = 1L;
+            long negativeAmount = -1000L;
+            String idempotencyKey = "test-key";
+
+            given(memberService.findById(memberId))
+                    .willReturn(Optional.of(validMember));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.createOrder(memberId, negativeAmount, idempotencyKey))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_AMOUNT.getMessage());
+        }
+
+        @Test
+        @DisplayName("0원 금액으로 주문 생성 시 InvalidAmountException 발생")
+        void createOrder_WithZeroAmount_ThrowsInvalidAmountException() {
+            // given
+            long memberId = 1L;
+            long zeroAmount = 0L;
+            String idempotencyKey = "test-key";
+
+            given(memberService.findById(memberId))
+                    .willReturn(Optional.of(validMember));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.createOrder(memberId, zeroAmount, idempotencyKey))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_AMOUNT.getMessage());
+        }
+
+        @Test
+        @DisplayName("중복된 멱등 키로 주문 생성 시 IdempotencyConflictException 발생")
+        void createOrder_WithDuplicateIdempotencyKey_ThrowsIdempotencyConflictException() {
+            // given
+            long memberId = 1L;
+            long totalAmount = 10000L;
+            String duplicateKey = "duplicate-key";
+
+            given(memberService.findById(memberId))
+                    .willReturn(Optional.of(validMember));
+            
+            // TODO: IdempotencyKeyService Mock 설정 (Phase 2 후반에 구현)
+            // given(idempotencyKeyService.existsByKeyAndEndpoint(duplicateKey, "POST /api/orders"))
+            //         .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> orderService.createOrder(memberId, totalAmount, duplicateKey))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.IDEMPOTENCY_CONFLICT.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrder 실패 케이스")
+    class GetOrderFailureTest {
+
+        @Test
+        @DisplayName("존재하지 않는 주문 조회 시 OrderNotFoundException 발생")
+        void getOrder_WithNonExistentOrder_ThrowsOrderNotFoundException() {
+            // given
+            long nonExistentOrderId = 999L;
+
+            given(orderRepository.findById(nonExistentOrderId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.getOrder(nonExistentOrderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("권한 없는 주문 조회 시 AccessDeniedException 발생")
+        void getOrder_WithUnauthorizedAccess_ThrowsAccessDeniedException() {
+            // given
+            long orderId = 1L;
+            long unauthorizedMemberId = 2L; // 다른 회원
+
+            Order order = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.PENDING); // 다른 회원의 주문
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(order));
+
+            // TODO: 현재 사용자 인증 정보 Mock 설정 필요
+            // when & then
+            assertThatThrownBy(() -> orderService.getOrder(orderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ACCESS_DENIED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("listOrders 실패 케이스")
+    class ListOrdersFailureTest {
+
+        @Test
+        @DisplayName("잘못된 페이지 번호로 주문 목록 조회 시 InvalidPaginationException 발생")
+        void listOrders_WithInvalidPageNumber_ThrowsInvalidPaginationException() {
+            // given
+            Long memberId = 1L;
+            OrderStatus status = OrderStatus.PENDING;
+            int invalidPage = -1; // 음수 페이지
+            int size = 10;
+
+            // when & then
+            assertThatThrownBy(() -> orderService.listOrders(memberId, status, invalidPage, size))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_PAGINATION.getMessage());
+        }
+
+        @Test
+        @DisplayName("잘못된 페이지 크기로 주문 목록 조회 시 InvalidPaginationException 발생")
+        void listOrders_WithInvalidPageSize_ThrowsInvalidPaginationException() {
+            // given
+            Long memberId = 1L;
+            OrderStatus status = OrderStatus.PENDING;
+            int page = 0;
+            int invalidSize = 0; // 0 또는 음수 크기
+
+            // when & then
+            assertThatThrownBy(() -> orderService.listOrders(memberId, status, page, invalidSize))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_PAGINATION.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원으로 주문 목록 조회 시 InvalidFilterException 발생")
+        void listOrders_WithNonExistentMember_ThrowsInvalidFilterException() {
+            // given
+            Long nonExistentMemberId = 999L;
+            OrderStatus status = OrderStatus.PENDING;
+            int page = 0;
+            int size = 10;
+
+            given(memberService.findById(nonExistentMemberId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.listOrders(nonExistentMemberId, status, page, size))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_FILTER.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelOrder 실패 케이스")
+    class CancelOrderFailureTest {
+
+        @Test
+        @DisplayName("존재하지 않는 주문 취소 시 OrderNotFoundException 발생")
+        void cancelOrder_WithNonExistentOrder_ThrowsOrderNotFoundException() {
+            // given
+            long nonExistentOrderId = 999L;
+            String reason = "취소 사유";
+
+            given(orderRepository.findById(nonExistentOrderId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(nonExistentOrderId, reason))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 취소된 주문 취소 시 AlreadyCanceledException 발생")
+        void cancelOrder_WithAlreadyCanceledOrder_ThrowsAlreadyCanceledException() {
+            // given
+            long orderId = 1L;
+            String reason = "취소 사유";
+
+            Order canceledOrder = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.CANCELED);
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(canceledOrder));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(orderId, reason))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ALREADY_CANCELED.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 결제된 주문 취소 시 InvalidOrderStateException 발생")
+        void cancelOrder_WithPaidOrder_ThrowsInvalidOrderStateException() {
+            // given
+            long orderId = 1L;
+            String reason = "취소 사유";
+
+            Order paidOrder = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.PAID);
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(paidOrder));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(orderId, reason))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_ORDER_STATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("중복된 멱등 키로 주문 취소 시 IdempotencyConflictException 발생")
+        void cancelOrder_WithDuplicateIdempotencyKey_ThrowsIdempotencyConflictException() {
+            // given
+            long orderId = 1L;
+            String reason = "취소 사유";
+            String duplicateKey = "duplicate-cancel-key";
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(validOrder));
+            
+            // TODO: IdempotencyKeyService Mock 설정 (Phase 2 후반에 구현)
+            // given(idempotencyKeyService.existsByKeyAndEndpoint(duplicateKey, "POST /api/orders/{orderId}/cancel"))
+            //         .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> orderService.cancelOrder(orderId, reason))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.IDEMPOTENCY_CONFLICT.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("handlePaymentApproved 실패 케이스")
+    class HandlePaymentApprovedFailureTest {
+
+        @Test
+        @DisplayName("존재하지 않는 주문에 대한 결제 승인 시 OrderNotFoundException 발생")
+        void handlePaymentApproved_WithNonExistentOrder_ThrowsOrderNotFoundException() {
+            // given
+            long nonExistentOrderId = 999L;
+
+            given(orderRepository.findById(nonExistentOrderId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.handlePaymentApproved(nonExistentOrderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 결제된 주문에 대한 중복 승인 시 DuplicateApprovalException 발생")
+        void handlePaymentApproved_WithAlreadyPaidOrder_ThrowsDuplicateApprovalException() {
+            // given
+            long orderId = 1L;
+
+            Order paidOrder = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.PAID);
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(paidOrder));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.handlePaymentApproved(orderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.DUPLICATE_APPROVAL.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 취소된 주문에 대한 결제 승인 시 InvalidOrderStateException 발생")
+        void handlePaymentApproved_WithCanceledOrder_ThrowsInvalidOrderStateException() {
+            // given
+            long orderId = 1L;
+
+            Order canceledOrder = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.CANCELED);
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(canceledOrder));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.handlePaymentApproved(orderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_ORDER_STATE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("handlePaymentCanceled 실패 케이스")
+    class HandlePaymentCanceledFailureTest {
+
+        @Test
+        @DisplayName("존재하지 않는 주문에 대한 결제 취소 시 OrderNotFoundException 발생")
+        void handlePaymentCanceled_WithNonExistentOrder_ThrowsOrderNotFoundException() {
+            // given
+            long nonExistentOrderId = 999L;
+
+            given(orderRepository.findById(nonExistentOrderId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> orderService.handlePaymentCanceled(nonExistentOrderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("결제되지 않은 주문에 대한 결제 취소 시 InvalidOrderStateException 발생")
+        void handlePaymentCanceled_WithUnpaidOrder_ThrowsInvalidOrderStateException() {
+            // given
+            long orderId = 1L;
+
+            Order unpaidOrder = Order.createTestOrder(orderId, 1L, 10000L, OrderStatus.PENDING);
+
+            given(orderRepository.findById(orderId))
+                    .willReturn(Optional.of(unpaidOrder));
+
+            // when & then
+            assertThatThrownBy(() -> orderService.handlePaymentCanceled(orderId))
+                    .isInstanceOf(OrderHandler.class)
+                    .hasMessage(OrderErrorStatus.INVALID_ORDER_STATE.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---


### 요약
TDD 계획서 Phase 2에 따라 OrderService의 실패 케이스 테스트를 작성했습니다. 이는 Red-Green-Refactor 사이클의 Red 단계로, 구현 전에 실패하는 테스트를 먼저 작성하여 비즈니스 요구사항을 명확히 정의하는 것이 목적입니다.

### 관련 이슈
- Close: #51 
-
### 변경 사항
- **OrderService 인터페이스 정의**: 6개 핵심 메서드 시그니처 정의
- **예외 클래스 확장**: OrderErrorStatus에 11개 새로운 예외 상태 추가
- **도메인 이벤트 클래스**: PaymentApprovedEvent, PaymentCanceledEvent 정의
- **Repository 인터페이스**: OrderRepository JPA 인터페이스 정의
- **테스트 유틸리티**: Order.createTestOrder() 메서드 추가
- **실패 케이스 테스트**: 19개 실패 케이스 테스트 작성

### 스크린샷/로그 (선택)
```
OrderService 실패 케이스 테스트 > createOrder 실패 케이스 > 존재하지 않는 회원으로 주문 생성 시 MemberNotFoundException 발생 FAILED
OrderService 실패 케이스 테스트 > createOrder 실패 케이스 > 비활성 회원으로 주문 생성 시 InactiveMemberException 발생 FAILED
...
19 tests completed, 19 failed
```
모든 테스트가 예상대로 `UnsupportedOperationException("Not implemented yet")`로 실패하여 TDD Red 단계 성공 확인

### 테스트
- [x] 단위/통합 테스트 추가 또는 업데이트
- [x] 로컬에서 기본 시나리오 테스트 완료
- [x] 회귀 영향 구역 점검

### 체크리스트
- [x] 빌드 성공 확인
- [x] 문서/README/주석 업데이트 (필요 시)
- [x] Breaking Change 여부 확인 및 고지
- [x] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
이 PR은 TDD Red 단계로, 모든 테스트가 실패하는 것이 정상입니다. 다음 단계인 Green 단계에서 실제 구현을 통해 모든 테스트를 통과시키는 작업이 필요합니다.

#### 주요 구현 내용

**1. OrderService 인터페이스**
```java
public interface OrderService {
    Order createOrder(long memberId, long totalAmount, @Nullable String idempotencyKey);
    Optional<Order> getOrder(long orderId);
    List<Order> listOrders(@Nullable Long memberId, @Nullable OrderStatus status, int page, int size);
    Order cancelOrder(long orderId, @Nullable String reason);
    void handlePaymentApproved(long orderId);
    void handlePaymentCanceled(long orderId);
}
```

**2. 추가된 예외 상태**
- `MEMBER_NOT_FOUND`: 존재하지 않는 회원
- `INACTIVE_MEMBER`: 비활성 회원
- `INVALID_AMOUNT`: 유효하지 않은 주문 금액
- `IDEMPOTENCY_CONFLICT`: 멱등 키 충돌
- `ACCESS_DENIED`: 권한 없는 주문 조회
- `INVALID_FILTER`: 잘못된 필터 조건
- `INVALID_PAGINATION`: 잘못된 페이지네이션 파라미터
- `INVALID_ORDER_STATE`: 잘못된 주문 상태
- `ALREADY_CANCELED`: 이미 취소된 주문
- `DUPLICATE_APPROVAL`: 중복 승인 시도

**3. 테스트 케이스 (19개)**
- **createOrder()**: 5개 실패 케이스
- **getOrder()**: 2개 실패 케이스  
- **listOrders()**: 3개 실패 케이스
- **cancelOrder()**: 4개 실패 케이스
- **handlePaymentApproved()**: 3개 실패 케이스
- **handlePaymentCanceled()**: 2개 실패 케이스

**4. 테스트 유틸리티 개선**
```java
public static Order createTestOrder(Long id, Long memberId, Long totalAmount, OrderStatus status) {
    // Reflection을 사용하여 테스트용 Order 객체 생성
    // Member.createTestMember()와 동일한 패턴으로 코드 중복 제거
}
```

#### 다음 단계
- TDD Green 단계: OrderServiceImpl 실제 구현
- IdempotencyKeyService 구현 (Phase 2 후반)
- 통합 테스트 작성 (Phase 4)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 주문 생성·조회·목록·취소 및 결제 승인·취소 이벤트 처리 기능 기반 추가
  - 주문 목록 필터(회원, 상태)와 페이지네이션 지원
  - 오류 상태/코드 확장: 존재하지 않는/비활성 회원, 잘못된 금액·필터·페이지네이션, 권한 거부, 잘못된 주문 상태, 이미 취소/중복 승인, 멱등성 충돌 등
- 테스트
  - 실패 시나리오 중심의 단위 테스트 추가로 예외 타입과 사용자 메시지 일관성 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->