### PR TITLE
[refactor] 멱등성 키 서비스 구현을 위한 메서드 구현부 제거

### DIFF
--- a/order/src/main/java/com/ipia/order/idempotency/service/IdempotencyKeyServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/idempotency/service/IdempotencyKeyServiceImpl.java
@@ -26,68 +26,32 @@ public class IdempotencyKeyServiceImpl implements IdempotencyKeyService {
     @Override
     @Transactional
     public <T> T executeWithIdempotency(String endpoint, String key, Supplier<T> operation) {
-        validateKey(key);
-
-        Optional<IdempotencyKey> existing = findByIdempotencyKey(endpoint, key);
-        if (existing.isPresent()) {
-            return deserialize(existing.get().getResponseJson());
-        }
-
-        T result;
-        try {
-            result = operation.get();
-        } catch (RuntimeException e) {
-            throw e; // 비즈니스 예외 전파
-        }
-
-        String responseJson = serialize(result);
-        saveIdempotencyKey(endpoint, key, responseJson);
-        return result;
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
     @Cacheable(cacheNames = CACHE_NAME, key = "#endpoint + ':' + #key")
     public Optional<IdempotencyKey> findByIdempotencyKey(String endpoint, String key) {
-        validateKey(key);
-        try {
-            return repository.findByEndpointAndKey(endpoint, key);
-        } catch (RuntimeException e) {
-            throw new IdempotencyHandler(IdempotencyErrorStatus.REPOSITORY_ERROR);
-        }
+        throw new UnsupportedOperationException("not implemented");
     }
 
     @Override
     @Transactional
     @CachePut(cacheNames = CACHE_NAME, key = "#endpoint + ':' + #key")
     public IdempotencyKey saveIdempotencyKey(String endpoint, String key, String responseJson) {
-        if (responseJson == null) {
-            throw new IdempotencyHandler(IdempotencyErrorStatus.REPOSITORY_ERROR);
-        }
-        try {
-            IdempotencyKey entity = new IdempotencyKey(endpoint, key, responseJson, Instant.now());
-            return repository.save(entity);
-        } catch (RuntimeException e) {
-            throw new IdempotencyHandler(IdempotencyErrorStatus.REPOSITORY_ERROR);
-        }
+        throw new UnsupportedOperationException("not implemented");
     }
 
     private void validateKey(String key) {
-        if (key == null || key.trim().isEmpty()) {
-            throw new IdempotencyHandler(IdempotencyErrorStatus.INVALID_IDEMPOTENCY_KEY);
-        }
+        throw new UnsupportedOperationException("not implemented");
     }
 
     private <T> String serialize(T result) {
-        try {
-            return String.valueOf(result); // TODO: ObjectMapper 주입 후 교체
-        } catch (RuntimeException e) {
-            throw new IdempotencyHandler(IdempotencyErrorStatus.RESPONSE_SERIALIZATION_ERROR);
-        }
+        throw new UnsupportedOperationException("not implemented");
     }
 
     private <T> T deserialize(String json) {
-        // 테스트 단계에서는 사용하지 않음. 실제 구현 시 ObjectMapper 사용
-        throw new UnsupportedOperationException("deserialize not implemented");
+        throw new UnsupportedOperationException("not implemented");
     }
 }
 


### PR DESCRIPTION


## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

### 관련 이슈
- Close: #

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- executeWithIdempotency, findByIdempotencyKey, saveIdempotencyKey, validateKey, serialize, deserialize 메서드에 UnsupportedOperationException 추가
- 기존 로직 제거 및 메서드 골격만 남김
-
### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 멱등성 키 처리 로직을 전면 비활성화했습니다. 멱등성 키로 호출되는 작업은 즉시 미지원 오류를 반환하며, 이전의 결과 저장/재사용 흐름은 동작하지 않습니다. 이에 따라 멱등성 키에 의존하는 일부 주문 요청은 실패하거나, 재시도 시 중복 실행 방지가 보장되지 않을 수 있습니다.
* Chores
  * 추후 재구현을 위한 내부 정리 작업을 진행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->