### PR TITLE
[refactor] Order 상태 전이 로직 개선 및 테스트 업데이트 (#68)

### DIFF
--- a/order/src/main/java/com/ipia/order/order/enums/OrderStatus.java
+++ b/order/src/main/java/com/ipia/order/order/enums/OrderStatus.java
@@ -1,9 +1,16 @@
 package com.ipia.order.order.enums;
 
 public enum OrderStatus {
-    CREATED,    // 주문 생성됨
-    PENDING,    // 결제 진행 중
-    PAID,       // 결제 완료
-    CANCELED,   // 취소됨
-    COMPLETED   // 완료됨
+    // 기본 상태
+    CREATED,        // 주문 생성됨
+    CANCELED,       // 취소됨
+    COMPLETED,      // 완료됨
+
+    // 이행 중심 상태
+    PLACED,                 // 주문 접수
+    CONFIRMED,              // 승인/확인 (결제 승인 시 매핑)
+    FULFILLMENT_STARTED,    // 이행 시작
+    SHIPPED,                // 출고/배송 시작
+    DELIVERED,              // 고객 인도
+    CANCEL_REQUESTED        // 취소 요청 상태 (중간 표시용)
 }

--- a/order/src/test/java/com/ipia/order/idempotency/IdempotencyKeyServiceTest.java
+++ b/order/src/test/java/com/ipia/order/idempotency/IdempotencyKeyServiceTest.java
@@ -1,30 +1,30 @@
 package com.ipia.order.idempotency;
 
+import java.time.Instant;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.BDDMockito.given;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ipia.order.common.exception.idempotency.IdempotencyHandler;
 import com.ipia.order.common.exception.idempotency.status.IdempotencyErrorStatus;
 import com.ipia.order.idempotency.domain.IdempotencyKey;
 import com.ipia.order.idempotency.repository.IdempotencyKeyRepository;
 import com.ipia.order.idempotency.service.IdempotencyKeyService;
 import com.ipia.order.idempotency.service.IdempotencyKeyServiceImpl;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.BeforeEach;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.Mock;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.Instant;
-import java.util.Map;
-import java.util.function.Supplier;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.data.redis.core.HashOperations;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("IdempotencyKeyService 실패 케이스")
@@ -82,6 +82,9 @@ class IdempotencyKeyServiceTest {
             // Redis Mock 설정: 캐시 미스 시나리오
             given(hashOperations.get(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq("status"))).willReturn(null);
             given(valueOperations.setIfAbsent(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any())).willReturn(true);
+            // Repository Mock: save 성공 반환
+            given(repository.save(org.mockito.ArgumentMatchers.any(IdempotencyKey.class)))
+                    .willAnswer(inv -> inv.getArgument(0));
             
             Supplier<Map<String, Object>> op = () -> java.util.Map.of("result", "ok");
             @SuppressWarnings({"unchecked", "rawtypes"})
@@ -95,6 +98,9 @@ class IdempotencyKeyServiceTest {
             // Redis Mock 설정: 캐시 미스 시나리오
             given(hashOperations.get(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.eq("status"))).willReturn(null);
             given(valueOperations.setIfAbsent(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any())).willReturn(true);
+            // Repository Mock: save 성공 반환
+            given(repository.save(org.mockito.ArgumentMatchers.any(IdempotencyKey.class)))
+                    .willAnswer(inv -> inv.getArgument(0));
             
             Supplier<Map<String, Object>> op = () -> java.util.Map.of("v", 1);
             org.assertj.core.api.Assertions.assertThatCode(() -> {

--- a/order/src/test/java/com/ipia/order/web/controller/order/OrderControllerTest.java
+++ b/order/src/test/java/com/ipia/order/web/controller/order/OrderControllerTest.java
@@ -51,7 +51,7 @@ class OrderControllerTest {
     void setUp() {
         // 공통 Mock 설정
         Order mockOrder = createMockOrder(1L, 1L, 10000L, OrderStatus.CREATED);
-        Order mockOrder2 = createMockOrder(2L, 1L, 20000L, OrderStatus.PENDING);
+        Order mockOrder2 = createMockOrder(2L, 1L, 20000L, OrderStatus.CONFIRMED);
         
         // 주문 생성 Mock
         Mockito.when(orderService.createOrder(Mockito.eq(1L), Mockito.eq(10000L), Mockito.any()))


### PR DESCRIPTION
# feat: Order 상태 모델 리팩터링 (결제 분리 전제) (#68)

---

## 요약
Order 도메인의 상태를 실제 이행(fulfillment) 흐름에 맞춰 세분화하고, 결제는 별도 상태로 분리할 전제를 반영하여 `OrderStatus`와 전이 메서드를 리팩터링합니다. (현재 스코프는 Order만 적용)

## 관련 이슈
- Close: #68

## 변경 사항
- **OrderStatus 재설계**
  - 기존: CREATED, PENDING, PAID, CANCELED, COMPLETED
  - 변경: PLACED → CONFIRMED → FULFILLMENT_STARTED → SHIPPED → DELIVERED → COMPLETED / CANCELED
- **Order 전이 메서드 추가/교체**
  - 추가: `confirm()`, `startFulfillment()`, `ship()`, `deliver()`, `complete()`, `requestCancel()`, `cancel()`
  - 제거: `transitionToPending()`, `transitionToPaid()` (결제 분리 후 의미 모호)
- **서비스/테스트 반영**
  - 서비스 로직의 상태 참조 수정 (CONFIRMED/COMPLETED 흐름으로 대체)
  - 통합 테스트를 신규 플로우(PLACED→CONFIRMED→...→COMPLETED, CANCEL_REQUESTED→CANCELED)로 갱신
- **API/DTO/필터**
  - `status` 값 목록 업데이트 및 (향후) `paymentStatus` 분리 대비 사전 정리

## 스크린샷/로그 (선택)
```
BUILD SUCCESSFUL
All updated integration tests passed
```

## 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

## 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트
- [ ] Breaking Change 여부 확인 및 고지 (상태 값/전이 변경)
- [ ] 보안/비밀정보 노출 여부 점검

## 기타 참고 사항
- 결제 미도입 상태에서 `PAID` 개념을 `COMPLETED`와 혼동하지 않도록 주의가 필요합니다. 본 PR은 결제 분리 전제를 반영해 주문 이행 중심으로 상태를 명확히 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 주문 생성에 멱등키를 지원해 중복 요청에도 동일 주문이 반환됩니다.
  - 주문 상태가 세분화되었습니다: 생성→확정→이행 시작→배송→배송 완료→완료. 취소 요청 단계가 추가되었습니다.
  - 취소 플로우가 개선되어 “취소 요청”과 “최종 취소”를 분리하고, 어떤 단계에서 가능한지 명확해졌습니다.
- 리팩터링
  - 상태 전이 규칙을 강화해 잘못된 전이를 사전에 차단하고, 예외/오류 응답을 더 일관되게 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->