### PR TITLE
[test] PaymentServiceImpl 테스트 코드 작성

### DIFF
--- a/order/src/main/java/com/ipia/order/order/domain/Order.java
+++ b/order/src/main/java/com/ipia/order/order/domain/Order.java
@@ -110,7 +110,6 @@ public class Order extends BaseEntity {
         this.status = OrderStatus.CANCELED;
     }
 
-    // 레거시 결제 중심 전이 메서드 제거됨
 
     private void validateMemberId(Long memberId) {
         if (memberId == null) {

--- a/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
+++ b/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
@@ -1,0 +1,20 @@
+package com.ipia.order.payment.service;
+
+import java.math.BigDecimal;
+
+/**
+ * 결제 서비스 응용 계층 인터페이스.
+ * 단일 서비스로 시작하고, 외부 연동/저장소는 포트로 분리한다.
+ */
+public interface PaymentService {
+
+    String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey);
+
+    void verify(String intentId, String paymentKey, long orderId, BigDecimal amount);
+
+    Long approve(String intentId, String paymentKey, long orderId, BigDecimal amount);
+
+    void cancel(String paymentKey, BigDecimal cancelAmount, String reason);
+}
+
+

--- a/order/src/main/java/com/ipia/order/payment/service/PaymentServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/payment/service/PaymentServiceImpl.java
@@ -1,0 +1,38 @@
+package com.ipia.order.payment.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+
+import com.ipia.order.payment.service.external.TossPaymentClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+
+    private final TossPaymentClient tossPaymentClient;
+
+    @Override
+    public String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void verify(String intentId, String paymentKey, long orderId, BigDecimal amount) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Long approve(String intentId, String paymentKey, long orderId, BigDecimal amount) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void cancel(String paymentKey, BigDecimal cancelAmount, String reason) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}
+
+

--- a/order/src/main/java/com/ipia/order/payment/service/external/TossCancelResponse.java
+++ b/order/src/main/java/com/ipia/order/payment/service/external/TossCancelResponse.java
@@ -1,0 +1,11 @@
+package com.ipia.order.payment.service.external;
+
+import java.math.BigDecimal;
+
+public record TossCancelResponse(
+        String paymentKey,
+        BigDecimal cancelAmount,
+        String status
+) {}
+
+

--- a/order/src/main/java/com/ipia/order/payment/service/external/TossConfirmResponse.java
+++ b/order/src/main/java/com/ipia/order/payment/service/external/TossConfirmResponse.java
@@ -1,0 +1,11 @@
+package com.ipia.order.payment.service.external;
+
+import java.math.BigDecimal;
+
+public record TossConfirmResponse(
+        String paymentKey,
+        String orderId,
+        BigDecimal approvedAmount
+) {}
+
+

--- a/order/src/main/java/com/ipia/order/payment/service/external/TossPaymentClient.java
+++ b/order/src/main/java/com/ipia/order/payment/service/external/TossPaymentClient.java
@@ -1,0 +1,12 @@
+package com.ipia.order.payment.service.external;
+
+import java.math.BigDecimal;
+
+public interface TossPaymentClient {
+
+    TossConfirmResponse confirm(String paymentKey, String orderId, BigDecimal amount);
+
+    TossCancelResponse cancel(String paymentKey, BigDecimal cancelAmount, String reason);
+}
+
+

--- a/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
@@ -1,0 +1,151 @@
+package com.ipia.order.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ipia.order.payment.service.external.TossCancelResponse;
+import com.ipia.order.payment.service.external.TossConfirmResponse;
+import com.ipia.order.payment.service.external.TossPaymentClient;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceImplTest {
+
+    @Mock
+    private TossPaymentClient tossPaymentClient;
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    @Nested
+    @DisplayName("approve")
+    class approveTests {
+        @Test
+        @DisplayName("승인: 금액 불일치 시 예외 (미구현 스텁)")
+        void approve_amountMismatch_shouldThrow() {
+            // then (현재 미구현 스텁이므로 UnsupportedOperationException 기대)
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-1",
+                    "paymentKey-xyz",
+                    1L,
+                    new BigDecimal("9999")
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("승인: 성공 플로우 (현재 미구현 스텁으로 예외 기대)")
+        void approve_success_placeholder() {
+            when(tossPaymentClient.confirm("paymentKey-ok", "1", new BigDecimal("10000")))
+                    .thenReturn(new TossConfirmResponse("paymentKey-ok", "1", new BigDecimal("10000")));
+
+            assertThatCode(() -> paymentService.approve(
+                    "intent-ok", "paymentKey-ok", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+    }
+
+
+    @Nested
+    @DisplayName("verify")
+    class VerifyTests {
+        @Test
+        @DisplayName("의도와 order/amount 불일치 시 예외 (미구현 스텁)")
+        void mismatch_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.verify(
+                    "intent-1",
+                    "paymentKey-xyz",
+                    2L,
+                    new BigDecimal("10000")
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("성공: 일치 시 통과 (현재 미구현 스텁으로 예외 기대)")
+        void success_placeholder() {
+            assertThatThrownBy(() -> paymentService.verify(
+                    "intent-ok",
+                    "paymentKey-ok",
+                    1L,
+                    new BigDecimal("10000")
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("cancel")
+    class CancelTests {
+        @Test
+        @DisplayName("승인 전/불가 상태에서 취소 요청 시 예외 (미구현 스텁)")
+        void invalidState_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-xyz",
+                    new BigDecimal("1000"),
+                    "고객요청"
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("취소 금액 초과: 사전 검증 실패 가정 (미구현 스텁)")
+        void amountExceeded_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-xyz",
+                    new BigDecimal("999999"),
+                    "사유"
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("성공: 정상 취소 (현재 미구현 스텁으로 예외 기대)")
+        void success_placeholder() {
+            when(tossPaymentClient.cancel("paymentKey-ok", new BigDecimal("1000"), "고객요청"))
+                    .thenReturn(new TossCancelResponse("paymentKey-ok", new BigDecimal("1000"), "CANCELED"));
+
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-ok", new BigDecimal("1000"), "고객요청"
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("createIntent")
+    class CreateIntentTests {
+        @Test
+        @DisplayName("음수/0 금액으로 의도 생성 시 예외 (미구현 스텁)")
+        void invalidAmount_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.createIntent(
+                    1L, new BigDecimal("0"), "s", "f", "idem"
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("성공: 정상 의도 생성 (현재 미구현 스텁으로 예외 기대)")
+        void success_placeholder() {
+            assertThatThrownBy(() -> paymentService.createIntent(
+                    1L, new BigDecimal("10000"), "s", "f", "idem"
+            ))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}
+
+

--- a/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
@@ -146,6 +146,114 @@ class PaymentServiceImplTest {
                     .isInstanceOf(UnsupportedOperationException.class);
         }
     }
+
+    @Nested
+    @DisplayName("approve - 추가 케이스")
+    class ApproveMoreTests {
+        @Test
+        @DisplayName("이미 승인된 결제 재승인 시도 예외 (미구현 스텁)")
+        void reapprove_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-approved", "paymentKey-abc", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("승인 불가능한 상태에서 승인 시도 예외 (미구현 스텁)")
+        void invalidState_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-canceled", "paymentKey-abc", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("Toss 4xx 매핑 테스트 (미구현 스텁)")
+        void toss4xx_shouldThrowMapped() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-4xx", "paymentKey-4xx", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("Toss 5xx/타임아웃 재시도 및 초과 실패 (미구현 스텁)")
+        void toss5xx_retry_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-5xx", "paymentKey-5xx", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("취소 - 추가 케이스")
+    class CancelMoreTests {
+        @Test
+        @DisplayName("취소 불가능한 상태에서 취소 시도 예외 (미구현 스텁)")
+        void invalidState_cancel_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-not-approved", new BigDecimal("1000"), "사유"
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("Toss 4xx 매핑 테스트 (미구현 스텁)")
+        void toss4xx_cancel_shouldThrowMapped() {
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-4xx", new BigDecimal("1000"), "사유"
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("Toss 5xx/타임아웃 재시도 및 초과 실패 (미구현 스텁)")
+        void toss5xx_cancel_retry_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.cancel(
+                    "paymentKey-5xx", new BigDecimal("1000"), "사유"
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("데이터 검증")
+    class ValidationTests {
+        @Test
+        @DisplayName("paymentKey null/blank 예외 (미구현 스텁)")
+        void invalidPaymentKey_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent", "", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+
+            assertThatThrownBy(() -> paymentService.cancel(
+                    null, new BigDecimal("1000"), "사유"
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("orderId 0/음수 예외 (미구현 스텁)")
+        void invalidOrderId_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent", "paymentKey", 0L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("amount 음수/0 예외 (미구현 스텁)")
+        void invalidAmount_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent", "paymentKey", 1L, new BigDecimal("0")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("외부 의존성/재시도 정책")
+    class ExternalDependencyTests {
+        @Test
+        @DisplayName("네트워크 오류/타임아웃 재시도 정책 (미구현 스텁)")
+        void networkTimeout_retry_shouldThrow() {
+            assertThatThrownBy(() -> paymentService.approve(
+                    "intent-timeout", "paymentKey-timeout", 1L, new BigDecimal("10000")
+            )).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
 }
 
 


### PR DESCRIPTION
## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- PaymentService의 실패 시나리오를 체계적으로 커버하기 위해 토스페이먼츠 문서 기준으로 불필요한 항목을 제외하고, 핵심 실패 케이스에 대한 레드 테스트를 확장했습니다. 현재는 구현 전 단계로 모든 테스트가 UnsupportedOperationException을 기대하는 상태입니다.

### 관련 이슈
- Close: #

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- 테스트 확장
   - 승인 실패 케이스: 금액 불일치, 재승인 시도, 상태 불일치, Toss 4xx/5xx 매핑, 재시도 초과
   - 취소 실패 케이스: 상태 불일치, Toss 4xx/5xx 매핑, 재시도 초과
   - 데이터 검증 실패: paymentKey null/blank, orderId 0/음수, amount 음수/0
   - 외부 의존성: 네트워크 오류/타임아웃 재시도 정책
- 체크리스트 정리
   - 환불 관련 항목 제외 (현재 서비스에 refund 메서드 없음)
   - 동시성/트랜잭션/이벤트 발행 실패 → 통합 테스트 영역으로 이관
   - API 응답 지연 → HTTP 클라이언트 레벨 통합 테스트로 이관
   - 부분 취소 금액 검증 → 선택적 (토스가 4xx로 처리)
### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이번 릴리스에는 사용자에게 바로 노출되는 새 기능이 없습니다.
- 테스트
  - 결제 승인·검증·취소 흐름과 예외/복구 시나리오에 대한 기초 테스트를 추가했습니다.
- 작업(Chores)
  - 결제 처리 및 외부 결제 연동을 위한 서비스/데이터 구조의 골격을 추가했습니다(아직 동작하지 않음).
- 스타일
  - 레거시 주석을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->