### PR TITLE
[test] PaymentControllerTest 테스트 코드 작성

### DIFF
--- a/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
@@ -1,0 +1,56 @@
+package com.ipia.order.web.controller.payment;
+
+import java.math.BigDecimal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ipia.order.payment.service.PaymentService;
+
+@RestController
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    public PaymentController(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+
+    @PostMapping("/intent")
+    public ResponseEntity<IntentResponse> createIntent(@RequestBody IntentRequest request,
+                                                       @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<ApproveResponse> approve(@RequestBody ApproveRequest request,
+                                                   @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancel(@RequestBody CancelRequest request) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verify(@RequestBody VerifyRequest request,
+                                       @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    public record IntentRequest(long orderId, BigDecimal amount, String successUrl, String failUrl) {}
+    public record ApproveRequest(String intentId, String paymentKey, long orderId, BigDecimal amount) {}
+    public record CancelRequest(String paymentKey, BigDecimal cancelAmount, String reason) {}
+    public record VerifyRequest(String intentId, String paymentKey, long orderId, BigDecimal amount) {}
+    public record IntentResponse(String intentId) {}
+    public record ApproveResponse(Long paymentId) {}
+}
+
+

--- a/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
+++ b/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
@@ -1,0 +1,121 @@
+package com.ipia.order.web.controller.payment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.ipia.order.payment.service.PaymentService;
+
+@WebMvcTest(controllers = com.ipia.order.web.controller.payment.PaymentController.class)
+class PaymentControllerApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    @Test
+    @DisplayName("의도 생성 API: 성공시 intentId 반환")
+    void createIntent_success() throws Exception {
+        // given
+        var reqJson = "{" +
+                "\"orderId\":1," +
+                "\"amount\":10000," +
+                "\"successUrl\":\"https://success\"," +
+                "\"failUrl\":\"https://fail\"" +
+                "}";
+        when(paymentService.createIntent(eq(1L), eq(new BigDecimal("10000")), eq("https://success"), eq("https://fail"), any()))
+                .thenReturn("intent_123");
+
+        // when/then
+        mockMvc.perform(post("/api/payments/intent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqJson)
+                        .header("Idempotency-Key", "idem-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.intentId").value("intent_123"));
+
+        verify(paymentService).createIntent(1L, new BigDecimal("10000"), "https://success", "https://fail", "idem-1");
+    }
+
+    @Test
+    @DisplayName("결제 승인 API: 성공시 paymentId 반환")
+    void approve_success() throws Exception {
+        // given
+        var reqJson = "{" +
+                "\"intentId\":\"intent_123\"," +
+                "\"paymentKey\":\"pay_abc\"," +
+                "\"orderId\":1," +
+                "\"amount\":10000" +
+                "}";
+        when(paymentService.approve(eq("intent_123"), eq("pay_abc"), eq(1L), eq(new BigDecimal("10000")), any()))
+                .thenReturn(10L);
+
+        // when/then
+        mockMvc.perform(post("/api/payments/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqJson)
+                        .header("Idempotency-Key", "idem-2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.paymentId").value(10));
+
+        verify(paymentService).approve("intent_123", "pay_abc", 1L, new BigDecimal("10000"), "idem-2");
+    }
+
+    @Test
+    @DisplayName("결제 취소 API: 성공시 204 반환")
+    void cancel_success() throws Exception {
+        // given
+        var reqJson = "{" +
+                "\"paymentKey\":\"pay_abc\"," +
+                "\"cancelAmount\":5000," +
+                "\"reason\":\"user cancel\"" +
+                "}";
+
+        // when/then
+        mockMvc.perform(post("/api/payments/cancel")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqJson))
+                .andExpect(status().isNoContent());
+
+        verify(paymentService).cancel("pay_abc", new BigDecimal("5000"), "user cancel");
+    }
+
+    @Test
+    @DisplayName("결제 검증 API: 성공시 204 반환")
+    void verify_success() throws Exception {
+        // given
+        var reqJson = "{" +
+                "\"intentId\":\"intent_123\"," +
+                "\"paymentKey\":\"pay_abc\"," +
+                "\"orderId\":1," +
+                "\"amount\":10000" +
+                "}";
+
+        // when/then
+        mockMvc.perform(post("/api/payments/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqJson)
+                        .header("Idempotency-Key", "idem-3"))
+                .andExpect(status().isNoContent());
+
+        verify(paymentService).verify("intent_123", "pay_abc", 1L, new BigDecimal("10000"), "idem-3");
+    }
+}
+
+


### PR DESCRIPTION
## [test] PaymentController API 테스트 케이스 추가 (#79)

---

### 요약
- PaymentController의 승인/취소/검증/의도 생성 API에 대한 컨트롤러 레벨 테스트를 추가합니다.

### 관련 이슈
- Close: #79

### 변경 사항
- MockMvc 기반 API 테스트 클래스 추가
- 정상/예외 시나리오 테스트 케이스 작성
- 에러 응답(`PaymentErrorStatus`) 매핑 검증
- REST Docs 또는 스냅샷 테스트(택1)로 응답 스키마 고정

### 스크린샷/로그 (선택)
- 필요 시 REST Docs 스니펫/스냅샷 캡처 첨부

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 승인/취소 API는 외부 연동 Mock으로 테스트 예정(WireMock)

