### PR TITLE
[feat] PaymentController 구현

### DIFF
--- a/order/src/main/java/com/ipia/order/common/exception/payment/status/PaymentSuccessStatus.java
+++ b/order/src/main/java/com/ipia/order/common/exception/payment/status/PaymentSuccessStatus.java
@@ -6,6 +6,9 @@ import com.ipia.order.common.exception.general.status.SuccessResponse;
 
 public enum PaymentSuccessStatus implements SuccessResponse {
 
+    // 결제 의도 생성
+    INTENT_CREATED(HttpStatus.OK, "PAYMENT2000", "결제 임시 객체가 생성되었습니다."),
+
     // 결제 승인
     PAYMENT_APPROVED(HttpStatus.OK, "PAYMENT2001", "결제가 성공적으로 승인되었습니다."),
     
@@ -26,7 +29,10 @@ public enum PaymentSuccessStatus implements SuccessResponse {
     WEBHOOK_PROCESSED(HttpStatus.OK, "PAYMENT2007", "웹훅이 성공적으로 처리되었습니다."),
     
     // 결제 상태 동기화
-    PAYMENT_STATUS_SYNCED(HttpStatus.OK, "PAYMENT2008", "결제 상태가 성공적으로 동기화되었습니다.");
+    PAYMENT_STATUS_SYNCED(HttpStatus.OK, "PAYMENT2008", "결제 상태가 성공적으로 동기화되었습니다."),
+
+    // 결제 검증 완료
+    PAYMENT_VERIFIED(HttpStatus.OK, "PAYMENT2009", "결제가 성공적으로 검증되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/order/src/main/java/com/ipia/order/common/filter/JwtAuthenticationFilter.java
+++ b/order/src/main/java/com/ipia/order/common/filter/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Collections;
+import com.ipia.order.common.security.CurrentUser;
 
 /**
  * JWT 인증 필터
@@ -47,9 +48,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String role = jwtUtil.getRoleFromToken(token);
                 
                 // Spring Security 인증 객체 생성
+                CurrentUser principal = new CurrentUser(userId, email, role);
                 UsernamePasswordAuthenticationToken authentication = 
                     new UsernamePasswordAuthenticationToken(
-                        email,
+                        principal,
                         null,
                         Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
                     );

--- a/order/src/main/java/com/ipia/order/common/security/CurrentUser.java
+++ b/order/src/main/java/com/ipia/order/common/security/CurrentUser.java
@@ -1,0 +1,19 @@
+package com.ipia.order.common.security;
+
+public class CurrentUser {
+    private final Long memberId;
+    private final String email;
+    private final String role;
+
+    public CurrentUser(Long memberId, String email, String role) {
+        this.memberId = memberId;
+        this.email = email;
+        this.role = role;
+    }
+
+    public Long getMemberId() { return memberId; }
+    public String getEmail() { return email; }
+    public String getRole() { return role; }
+}
+
+

--- a/order/src/main/java/com/ipia/order/order/service/OrderService.java
+++ b/order/src/main/java/com/ipia/order/order/service/OrderService.java
@@ -1,13 +1,9 @@
 package com.ipia.order.order.service;
 
 import com.ipia.order.order.domain.Order;
-import com.ipia.order.order.enums.OrderStatus;
-import com.ipia.order.web.dto.response.order.OrderResponse;
 import com.ipia.order.web.dto.response.order.OrderListResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.lang.Nullable;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -35,15 +31,11 @@ public interface OrderService {
      */
     Order createOrder(long memberId, long totalAmount, @Nullable String idempotencyKey);
     
+
     /**
-     * 주문 단건 조회
-     * 
-     * @param orderId 주문 ID
-     * @return 주문 정보 (없으면 Optional.empty())
-     * @throws OrderHandler 존재하지 않는 주문 (OrderErrorStatus.ORDER_NOT_FOUND)
-     * @throws OrderHandler 권한 없는 주문 조회 (OrderErrorStatus.ACCESS_DENIED)
+     * 소유자 검증을 포함한 주문 조회
      */
-    Optional<Order> getOrder(long orderId);
+    Optional<Order> getOrder(long orderId, long requesterMemberId);
     
     /**
      * 주문 목록 조회 (페이지네이션)

--- a/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ipia.order.order.service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -81,7 +82,7 @@ public class OrderServiceImpl implements OrderService {
     public Optional<Order> getOrder(long orderId, long requesterMemberId) {
         log.info("[Order] 주문 단건 조회(소유자 확인) 요청: orderId={}, requesterId={}", orderId, requesterMemberId);
         Order order = findOrderById(orderId);
-        if (!java.util.Objects.equals(order.getMemberId(), requesterMemberId)) {
+        if (!Objects.equals(order.getMemberId(), requesterMemberId)) {
             throw new OrderHandler(OrderErrorStatus.ACCESS_DENIED);
         }
         return Optional.of(order);

--- a/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/order/service/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
+ 
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ipia.order.common.exception.order.OrderHandler;
@@ -74,11 +75,16 @@ public class OrderServiceImpl implements OrderService {
         return created;
     }
 
+ 
+
     @Override
-    public Optional<Order> getOrder(long orderId) {
-        log.info("[Order] 주문 단건 조회 요청: orderId={}", orderId);
-        findOrderById(orderId); // 주문 존재 여부만 확인
-        throw new OrderHandler(OrderErrorStatus.ACCESS_DENIED);
+    public Optional<Order> getOrder(long orderId, long requesterMemberId) {
+        log.info("[Order] 주문 단건 조회(소유자 확인) 요청: orderId={}, requesterId={}", orderId, requesterMemberId);
+        Order order = findOrderById(orderId);
+        if (!java.util.Objects.equals(order.getMemberId(), requesterMemberId)) {
+            throw new OrderHandler(OrderErrorStatus.ACCESS_DENIED);
+        }
+        return Optional.of(order);
     }
 
     @Override
@@ -249,4 +255,6 @@ public class OrderServiceImpl implements OrderService {
             }
         }
     }
+
+    // 인증 의존 제거: 소유자 검증은 컨트롤러 계층에서 requesterId를 받아 처리한다.
 }

--- a/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
+++ b/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
  */
 public interface PaymentService {
 
-    String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey);
+    String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl);
 
     void verify(String intentId, String paymentKey, long orderId, BigDecimal amount, String idempotencyKey);
 

--- a/order/src/main/java/com/ipia/order/web/controller/order/OrderController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/order/OrderController.java
@@ -12,6 +12,7 @@ import com.ipia.order.web.dto.request.order.CreateOrderRequest;
 import com.ipia.order.web.dto.request.order.CancelOrderRequest;
 import com.ipia.order.web.dto.response.order.OrderResponse;
 import com.ipia.order.web.dto.response.order.OrderListResponse;
+import com.ipia.order.common.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -83,8 +84,9 @@ public class OrderController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<OrderResponse>> getOrder(
             @Parameter(description = "주문 ID", example = "1") @PathVariable("id") Long id,
-            @AuthenticationPrincipal(expression = "memberId") Long memberId) {
-        
+            @Parameter(hidden = true) @AuthenticationPrincipal CurrentUser user) {
+       
+        Long memberId = user.getMemberId();
         Optional<Order> orderOptional = orderService.getOrder(id, memberId);
         
         if (orderOptional.isEmpty()) {

--- a/order/src/main/java/com/ipia/order/web/controller/order/OrderController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/order/OrderController.java
@@ -22,6 +22,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.Optional;
 
@@ -81,9 +82,10 @@ public class OrderController {
     })
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<OrderResponse>> getOrder(
-            @Parameter(description = "주문 ID", example = "1") @PathVariable("id") Long id) {
+            @Parameter(description = "주문 ID", example = "1") @PathVariable("id") Long id,
+            @AuthenticationPrincipal(expression = "memberId") Long memberId) {
         
-        Optional<Order> orderOptional = orderService.getOrder(id);
+        Optional<Order> orderOptional = orderService.getOrder(id, memberId);
         
         if (orderOptional.isEmpty()) {
             throw new OrderHandler(OrderErrorStatus.ORDER_NOT_FOUND);

--- a/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
@@ -42,14 +42,12 @@ public class PaymentController {
             @ApiErrorCodeExample(value = PaymentErrorStatus.class, codes = {"INVALID_AMOUNT", "INVALID_SUCCESS_URL", "INVALID_FAIL_URL"})
     })
     @PostMapping("/intent")
-    public ResponseEntity<ApiResponse<IntentResponse>> createIntent(@RequestBody IntentRequest request,
-                                                       @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {
+    public ResponseEntity<ApiResponse<IntentResponse>> createIntent(@RequestBody IntentRequest request) {
         String intentId = paymentService.createIntent(
                 request.orderId(),
                 request.amount(),
                 request.successUrl(),
-                request.failUrl(),
-                idempotencyKey
+                request.failUrl()
         );
         return ApiResponse.onSuccess(PaymentSuccessStatus.INTENT_CREATED, new IntentResponse(intentId));
     }

--- a/order/src/test/java/com/ipia/order/order/service/OrderServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/order/service/OrderServiceImplTest.java
@@ -201,7 +201,7 @@ class OrderServiceImplTest {
                     .willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> orderService.getOrder(nonExistentOrderId))
+            assertThatThrownBy(() -> orderService.getOrder(nonExistentOrderId, 1L))
                     .isInstanceOf(OrderHandler.class)
                     .hasMessage(OrderErrorStatus.ORDER_NOT_FOUND.getCode());
         }
@@ -225,7 +225,7 @@ class OrderServiceImplTest {
 
             // TODO: 현재 사용자 인증 정보 Mock 설정 필요
             // when & then
-            assertThatThrownBy(() -> orderService.getOrder(orderId))
+            assertThatThrownBy(() -> orderService.getOrder(orderId, unauthorizedMemberId))
                     .isInstanceOf(OrderHandler.class)
                     .hasMessage(OrderErrorStatus.ACCESS_DENIED.getCode());
         }

--- a/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
@@ -56,7 +56,7 @@ class PaymentServiceImplTest {
     @InjectMocks
     private PaymentServiceImpl paymentService;
 
-
+    
 
     @Nested
     @DisplayName("approve")
@@ -248,7 +248,7 @@ class PaymentServiceImplTest {
         @DisplayName("음수/0 금액으로 의도 생성 시 예외")
         void invalidAmount_shouldThrow() {
             assertThatThrownBy(() -> paymentService.createIntent(
-                    1L, new BigDecimal("0"), "s", "f", "idem"
+                    1L, new BigDecimal("0"), "s", "f"
             ))
                     .isInstanceOf(PaymentHandler.class);
         }
@@ -257,8 +257,13 @@ class PaymentServiceImplTest {
         @DisplayName("성공: 정상 의도 생성")
         void success_shouldReturnIntentId() {
             // when
+                when(idempotencyKeyService.executeWithIdempotency(any(), any(), any(), any()))
+                        .thenAnswer(inv -> {
+                            java.util.function.Supplier<?> op = inv.getArgument(3);
+                            return op.get();
+                        });
             String result = paymentService.createIntent(
-                    1L, new BigDecimal("10000"), "http://success", "http://fail", "idem-key"
+                    1L, new BigDecimal("10000"), "http://success", "http://fail"
             );
             
             // then
@@ -269,7 +274,7 @@ class PaymentServiceImplTest {
                 }
             }).doesNotThrowAnyException();
             verify(paymentIntentService).store(anyString(), eq(1L), eq(new BigDecimal("10000")), 
-                    eq("http://success"), eq("http://fail"), eq("idem-key"), eq(1800L));
+                    eq("http://success"), eq("http://fail"), anyString(), eq(1800L));
         }
     }
 

--- a/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
+++ b/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.math.BigDecimal;
 
 import com.ipia.order.common.util.JwtUtil;
-import com.ipia.order.web.controller.order.OrderController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,18 +45,17 @@ class PaymentControllerApiTest {
                 "\"successUrl\":\"https://success\"," +
                 "\"failUrl\":\"https://fail\"" +
                 "}";
-        when(paymentService.createIntent(eq(1L), eq(new BigDecimal("10000")), eq("https://success"), eq("https://fail"), any()))
+        when(paymentService.createIntent(eq(1L), eq(new BigDecimal("10000")), eq("https://success"), eq("https://fail")))
                 .thenReturn("intent_123");
 
         // when/then
         mockMvc.perform(post("/api/payments/intent")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(reqJson)
-                        .header("Idempotency-Key", "idem-1"))
+                        .content(reqJson))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.intentId").value("intent_123"));
+                .andExpect(jsonPath("$.data.intentId").isString());
 
-        verify(paymentService).createIntent(1L, new BigDecimal("10000"), "https://success", "https://fail", "idem-1");
+        verify(paymentService).createIntent(1L, new BigDecimal("10000"), "https://success", "https://fail");
     }
 
     @Test


### PR DESCRIPTION
## [feat] Payment REST API 컨트롤러 TDD 구현 (#81 )

---

### 요약
- Payment 도메인의 REST API 엔드포인트를 TDD로 구현합니다.
- 결제 승인/취소/환불/조회 API 및 요청/응답 DTO를 포함합니다.

### 관련 이슈
- Close: #81 
### 변경 사항
- PaymentController 클래스 생성
- REST API 엔드포인트 구현:
  - POST `/api/orders/{orderId}/payments/approve`
  - POST `/api/orders/{orderId}/payments/cancel`
  - POST `/api/orders/{orderId}/payments/refund`
  - GET `/api/payments/{paymentId}`
  - GET `/api/orders/{orderId}/payments`
- 요청/응답 DTO 클래스 생성
- API 검증 및 예외 처리 구현
- 슬라이스 테스트 추가 (WebMvcTest)

### 스크린샷/로그 (선택)
- API 문서 (Swagger/OpenAPI)
- 컨트롤러 테스트 실행 결과

### 테스트
- [x] 슬라이스 테스트 추가: WebMvcTest 기반 컨트롤러 테스트
- [x] API 계약 테스트 추가: 요청/응답 검증
- [x] 로컬에서 기본 시나리오 테스트 완료
- [x] 회귀 영향 구역 점검: API 계층 격리

### 체크리스트
- [x] 빌드 성공 확인
- [x] 문서/README/주석 업데이트 (필요 시)
- [x] Breaking Change 여부 확인 및 고지: 신규 API 추가
- [x] 보안/비밀정보 노출 여부 점검: 인증/인가 처리

### 기타 참고 사항
- API 버전 관리 고려 (v1 prefix)
- 인증/인가는 기존 Order API와 동일한 방식 적용
- API 문서화 (Swagger) 포함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 결제 API 응답을 표준 ApiResponse로 통일하고 성공 상태(INTENT_CREATED, PAYMENT_VERIFIED) 추가
  - 결제 검증 성공 응답 제공
- Changes
  - 주문 조회는 로그인한 사용자 본인 주문만 조회 가능하며 소유자 불일치 시 접근 거부
  - 결제 의도 생성 시 Idempotency-Key 제공이 불필요(승인 API는 기존 키 헤더 유지)
- Documentation
  - 결제 API에 Swagger 메타데이터와 오류 코드 예시 추가로 문서화 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->