### PR TITLE
[refactor] PaymentService createIntent 메서드 시그니처 변경 및 멱등성 키 통합

### DIFF
--- a/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
+++ b/order/src/main/java/com/ipia/order/payment/service/PaymentService.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
  */
 public interface PaymentService {
 
-    String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl);
+    String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey);
 
     void verify(String intentId, String paymentKey, long orderId, BigDecimal amount, String idempotencyKey);
 

--- a/order/src/main/java/com/ipia/order/payment/service/PaymentServiceImpl.java
+++ b/order/src/main/java/com/ipia/order/payment/service/PaymentServiceImpl.java
@@ -39,22 +39,19 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional
-    public String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl) {
+    public String createIntent(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey) {
         log.info("결제 의도 생성 요청: orderId={}, amount={}", orderId, amount);
 
         // 입력값 검증
-        validateCreateIntentParams(orderId, amount, successUrl, failUrl);
-
-        // 멱등키를 요청 파라미터로부터 파생 생성 (동일 주문/금액 조합 재시도 보호)
-        String derivedIdemKey = "intent:" + orderId + ":" + amount;
+        validateCreateIntentParams(orderId, amount, successUrl, failUrl, idempotencyKey);
 
         return idempotencyKeyService.executeWithIdempotency(
                 "POST /payments/intent",
-                derivedIdemKey,
+                idempotencyKey,
                 String.class,
                 () -> {
                     String intentId = generateIntentId();
-                    paymentIntentService.store(intentId, orderId, amount, successUrl, failUrl, derivedIdemKey, INTENT_TTL_SECONDS);
+                    paymentIntentService.store(intentId, orderId, amount, successUrl, failUrl, idempotencyKey, INTENT_TTL_SECONDS);
                     log.info("결제 의도 생성 완료: intentId={}, orderId={}, amount={}", intentId, orderId, amount);
                     return intentId;
                 }
@@ -171,7 +168,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     // ==================== 검증 메서드 ====================
 
-    private void validateCreateIntentParams(long orderId, BigDecimal amount, String successUrl, String failUrl) {
+    private void validateCreateIntentParams(long orderId, BigDecimal amount, String successUrl, String failUrl, String idempotencyKey) {
         if (orderId <= 0) {
             throw new PaymentHandler(PaymentErrorStatus.ORDER_ID_REQUIRED);
         }
@@ -183,6 +180,9 @@ public class PaymentServiceImpl implements PaymentService {
         }
         if (!StringUtils.hasText(failUrl)) {
             throw new PaymentHandler(PaymentErrorStatus.FAIL_URL_REQUIRED);
+        }
+        if (!StringUtils.hasText(idempotencyKey)) {
+            throw new PaymentHandler(PaymentErrorStatus.INVALID_IDEMPOTENCY_KEY);
         }
     }
 

--- a/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
+++ b/order/src/main/java/com/ipia/order/web/controller/payment/PaymentController.java
@@ -42,12 +42,14 @@ public class PaymentController {
             @ApiErrorCodeExample(value = PaymentErrorStatus.class, codes = {"INVALID_AMOUNT", "INVALID_SUCCESS_URL", "INVALID_FAIL_URL"})
     })
     @PostMapping("/intent")
-    public ResponseEntity<ApiResponse<IntentResponse>> createIntent(@RequestBody IntentRequest request) {
+    public ResponseEntity<ApiResponse<IntentResponse>> createIntent(@RequestBody IntentRequest request,
+                                                      @RequestHeader(name = "Idempotency-Key") String idempotencyKey) {
         String intentId = paymentService.createIntent(
                 request.orderId(),
                 request.amount(),
                 request.successUrl(),
-                request.failUrl()
+                request.failUrl(),
+                idempotencyKey
         );
         return ApiResponse.onSuccess(PaymentSuccessStatus.INTENT_CREATED, new IntentResponse(intentId));
     }

--- a/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
+++ b/order/src/test/java/com/ipia/order/payment/service/PaymentServiceImplTest.java
@@ -248,7 +248,7 @@ class PaymentServiceImplTest {
         @DisplayName("음수/0 금액으로 의도 생성 시 예외")
         void invalidAmount_shouldThrow() {
             assertThatThrownBy(() -> paymentService.createIntent(
-                    1L, new BigDecimal("0"), "s", "f"
+                    1L, new BigDecimal("0"), "s", "f", "test-idem-key"
             ))
                     .isInstanceOf(PaymentHandler.class);
         }
@@ -263,7 +263,7 @@ class PaymentServiceImplTest {
                             return op.get();
                         });
             String result = paymentService.createIntent(
-                    1L, new BigDecimal("10000"), "http://success", "http://fail"
+                    1L, new BigDecimal("10000"), "http://success", "http://fail", "test-idem-key"
             );
             
             // then

--- a/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
+++ b/order/src/test/java/com/ipia/order/web/controller/payment/PaymentControllerApiTest.java
@@ -45,17 +45,18 @@ class PaymentControllerApiTest {
                 "\"successUrl\":\"https://success\"," +
                 "\"failUrl\":\"https://fail\"" +
                 "}";
-        when(paymentService.createIntent(eq(1L), eq(new BigDecimal("10000")), eq("https://success"), eq("https://fail")))
+        when(paymentService.createIntent(eq(1L), eq(new BigDecimal("10000")), eq("https://success"), eq("https://fail"), eq("idem-1")))
                 .thenReturn("intent_123");
 
         // when/then
         mockMvc.perform(post("/api/payments/intent")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(reqJson))
+                        .content(reqJson)
+                        .header("Idempotency-Key", "idem-1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.intentId").isString());
 
-        verify(paymentService).createIntent(1L, new BigDecimal("10000"), "https://success", "https://fail");
+        verify(paymentService).createIntent(1L, new BigDecimal("10000"), "https://success", "https://fail", "idem-1");
     }
 
     @Test


### PR DESCRIPTION


## PR 제목

관련 이슈 번호를 포함해 간결하고 명확하게 작성해주세요. (예: "feat: 주문 생성 API 추가 (#123)")

---

### 요약
- 이 PR의 목적과 배경을 한두 문장으로 설명해주세요.

### 관련 이슈
- Close: #

### 변경 사항
- 무엇이 어떻게 변경되었는지 항목으로 정리해주세요.
- API/스키마 변경 시 명시해주세요.

- createIntent 메서드에 idempotencyKey 파라미터 추가
- 관련된 검증 로직 및 테스트 케이스 업데이트
- PaymentController에서 idempotencyKey를 요청 헤더로 수신하도록 수정
- 
### 스크린샷/로그 (선택)
- UI 변경, 주요 로그 등 확인에 도움이 되는 자료를 첨부해주세요.

### 테스트
- [ ] 단위/통합 테스트 추가 또는 업데이트
- [ ] 로컬에서 기본 시나리오 테스트 완료
- [ ] 회귀 영향 구역 점검

### 체크리스트
- [ ] 빌드 성공 확인
- [ ] 문서/README/주석 업데이트 (필요 시)
- [ ] Breaking Change 여부 확인 및 고지
- [ ] 보안/비밀정보 노출 여부 점검

### 기타 참고 사항
- 리뷰어에게 도움이 될 만한 추가 맥락을 남겨주세요.


